### PR TITLE
Adjust style and layout of entities search (#8, #3)

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -17,7 +17,7 @@ module.exports = {
     plugins: ["react", "jsdoc"],
     rules: {
         quotes: ["error", "double"],
-        indent: ["error", 4],
+        indent: ["error", 4, { SwitchCase: 1 }],
         "react/jsx-indent": ["error", 4],
         "react/jsx-indent-props": ["error", 4],
         "react/prop-types": [0],

--- a/src/components/EntitiesResults.css
+++ b/src/components/EntitiesResults.css
@@ -1,0 +1,17 @@
+th,
+td {
+    padding: 10px;
+    border: 1px solid #d3dae6;
+}
+th {
+    background: #f5f7fa;
+    text-align: left;
+}
+th:last-child {
+    width: 15%;
+}
+table {
+    margin-bottom: 2rem;
+    line-height: 1.25;
+    width: 100%;
+}

--- a/src/components/EntitiesResults.jsx
+++ b/src/components/EntitiesResults.jsx
@@ -1,29 +1,40 @@
-import { EuiFlexGrid, EuiHorizontalRule, EuiFlexItem } from "@elastic/eui";
-import React from "react";
+import "./EntitiesResults.css";
 
 /**
  * List of results for the Entities search view.
  *
  * @param {object} props Props for React functional component
  * @param {object} props.data Data returned by ElasticSearch
+ * @param {number} props.offset Offset of results for current page
  * @returns Populated results list React component
  */
-function EntitiesResults({ data }) {
+function EntitiesResults({ data, offset }) {
     return (
-        <EuiFlexGrid columns={1}>
-            {data?.hits.items.map((hit) => (
-                <React.Fragment
-                    key={hit.id}
-                >
-                    <EuiFlexItem
-                        dangerouslySetInnerHTML={{
-                            __html: hit?.fields?.short_display,
-                        }}
-                    />
-                    <EuiHorizontalRule />
-                </React.Fragment>
-            ))}
-        </EuiFlexGrid>
+        <table>
+            <thead>
+                <th aria-label="index">#</th>
+                <th>Entity</th>
+                <th>Type</th>
+            </thead>
+            <tbody>
+                {data?.hits?.items?.map((entity, idx) => (
+                    <tr key={entity.id}>
+                        <td>{idx + 1 + (offset || 0)}</td>
+                        <td
+                            // eslint-disable-next-line react/no-danger
+                            dangerouslySetInnerHTML={{
+                                __html: entity?.fields?.short_display,
+                            }}
+                        />
+                        <td className="capital-label">
+                            {entity?.fields?.e_type
+                                .toString()
+                                .replaceAll("_", " ")}
+                        </td>
+                    </tr>
+                ))}
+            </tbody>
+        </table>
     );
 }
 

--- a/src/components/EntitiesResults.jsx
+++ b/src/components/EntitiesResults.jsx
@@ -12,13 +12,15 @@ function EntitiesResults({ data, offset }) {
     return (
         <table>
             <thead>
-                <th aria-label="index">#</th>
-                <th>Entity</th>
-                <th>Type</th>
+                <tr>
+                    <th aria-label="index">#</th>
+                    <th>Entity</th>
+                    <th>Type</th>
+                </tr>
             </thead>
             <tbody>
                 {data?.hits?.items?.map((entity, idx) => (
-                    <tr key={entity.id}>
+                    <tr key={entity.id} id={entity.id}>
                         <td>{idx + 1 + (offset || 0)}</td>
                         <td
                             // eslint-disable-next-line react/no-danger

--- a/src/components/ListFacet.jsx
+++ b/src/components/ListFacet.jsx
@@ -41,7 +41,9 @@ function ListFacet({ facet, loading }) {
                 }}
                 filter={{ identifier: facet.identifier, value: entry.label }}
             >
-                {entry.label.toString().replaceAll("_", " ")}
+                <span className="capital-label">
+                    {entry.label.toString().replaceAll("_", " ")}
+                </span>
             </FilterLink>
         </EuiFacetButton>
     ));

--- a/src/pages/EntitiesSearch.css
+++ b/src/pages/EntitiesSearch.css
@@ -1,3 +1,3 @@
-.euiFacetButton__text a {
+.capital-label {
     text-transform: capitalize;
 }

--- a/src/pages/EntitiesSearch.jsx
+++ b/src/pages/EntitiesSearch.jsx
@@ -67,7 +67,7 @@ const config = {
     },
     index: import.meta.env.VITE_SEARCHKIT_ENTITIES_INDEX,
     hits: {
-        fields: ["id", "short_display"],
+        fields: ["id", "short_display", "e_type"],
     },
     query: getEntitiesQuery({ analyzers, fields }),
     facets: [
@@ -150,7 +150,10 @@ function EntitiesSearch() {
                                 </EuiPageContentHeaderSection>
                             </EuiPageContentHeader>
                             <EuiPageContentBody>
-                                <EntitiesResults data={results} />
+                                <EntitiesResults
+                                    data={results}
+                                    offset={variables?.page?.from}
+                                />
                                 <EuiFlexGroup justifyContent="spaceAround">
                                     <Pagination data={results} />
                                 </EuiFlexGroup>

--- a/src/pages/EntitiesSearch.jsx
+++ b/src/pages/EntitiesSearch.jsx
@@ -1,10 +1,7 @@
 import { RefinementSelectFacet } from "@ecds/searchkit-sdk";
 // eslint-disable-next-line import/no-unresolved
 import { useSearchkitSDK } from "@ecds/searchkit-sdk/src/react-hooks";
-import {
-    useSearchkitVariables,
-    withSearchkit,
-} from "@searchkit/client";
+import { useSearchkitVariables, withSearchkit } from "@searchkit/client";
 import {
     SearchBar,
     ResetSearchButton,
@@ -82,6 +79,7 @@ const config = {
     ],
     /**
      * Appends { published: true } filter when there is no query term.
+     * Also removes "generic" type from facet list.
      *
      * @param {object} body The original request body object
      * @returns The modified request body for ElasticSearch
@@ -90,7 +88,12 @@ const config = {
         ? body
         : {
             ...body,
-            query: { bool: { must: [{ term: { published: true } }] } },
+            query: {
+                bool: {
+                    must: [{ term: { published: true } }],
+                    must_not: [{ term: { e_type: "generic" } }],
+                },
+            },
         }),
 };
 


### PR DESCRIPTION
## In this PR

- Per #3:
  - Filter all "generic" type entities out of search
- Per #8:
  - Adjust style and layout of entities search to match design
  - Display index, entity type for each result