### PR TITLE
Letters search (#5, #14, #16, #17)

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -52,5 +52,6 @@ module.exports = {
         ],
         "jsdoc/require-returns-type": [0],
         "import/prefer-default-export": "off",
+        "no-unused-vars": ["error", { destructuredArrayIgnorePattern: "^_" }],
     },
 };

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -51,5 +51,6 @@ module.exports = {
             },
         ],
         "jsdoc/require-returns-type": [0],
+        "import/prefer-default-export": "off",
     },
 };

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <script>
       var global = global || window;
     </script>
-    <title>Beckett Entities Search</title>
+    <title>Samuel Beckett Letters</title>
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
                 "@elastic/eui": "^34.6.0",
                 "@searchkit/client": "^3.0.0",
                 "@searchkit/elastic-ui": "^3.0.0",
-                "date-fns": "^2.29.3",
+                "@searchkit/schema": "^3.0.0",
+                "moment": "^2.29.4",
                 "react": "^16.14.0",
                 "react-dom": "^16.14.0",
                 "react-router-dom": "^6.4.2"
@@ -918,6 +919,50 @@
                 "react": "^17.0.0||^16.0.0"
             }
         },
+        "node_modules/@searchkit/schema": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@searchkit/schema/-/schema-3.0.0.tgz",
+            "integrity": "sha512-JUBLhIGLxpsroVv+7ad2hfZTFboDO+isXS+60cYocWI2hl48fR3ZQuZ5ZErH6kADPOg6PRT1t6UyLRpUYX4Vrg==",
+            "dependencies": {
+                "@elastic/elasticsearch": "7.13.0",
+                "@searchkit/sdk": "^3.0.0",
+                "dataloader": "^2.0.0",
+                "graphql-tag": "^2.10.3",
+                "lodash": "^4.17.21"
+            }
+        },
+        "node_modules/@searchkit/schema/node_modules/@elastic/elasticsearch": {
+            "version": "7.13.0",
+            "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-7.13.0.tgz",
+            "integrity": "sha512-WgwLWo2p9P2tdqzBGX9fHeG8p5IOTXprXNTECQG2mJ7z9n93N5AFBJpEw4d35tWWeCWi9jI13A2wzQZH7XZ/xw==",
+            "dependencies": {
+                "debug": "^4.3.1",
+                "hpagent": "^0.1.1",
+                "ms": "^2.1.3",
+                "secure-json-parse": "^2.4.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@searchkit/schema/node_modules/hpagent": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-0.1.2.tgz",
+            "integrity": "sha512-ePqFXHtSQWAFXYmj+JtOTHr84iNrII4/QRlAAPPE+zqnKy4xJo7Ie1Y4kC7AdB+LxLxSTTzBMASsEcy0q8YyvQ=="
+        },
+        "node_modules/@searchkit/sdk": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@searchkit/sdk/-/sdk-3.0.0.tgz",
+            "integrity": "sha512-cWtP5T2+xonPhnwDmda6+RQWvGBg0bigCmZLm+fPPJOymEIug5LQF1s0abcWlwDuXhNnMqiCdk/x2ZUJpt2xTA==",
+            "dependencies": {
+                "@elastic/elasticsearch-types": "npm:@elastic/elasticsearch@^8.2.1",
+                "agentkeepalive": "^4.1.3",
+                "lodash": "^4.17.21"
+            },
+            "peerDependencies": {
+                "@elastic/elasticsearch": "*"
+            }
+        },
         "node_modules/@types/chroma-js": {
             "version": "2.1.4",
             "resolved": "https://registry.npmjs.org/@types/chroma-js/-/chroma-js-2.1.4.tgz",
@@ -1623,17 +1668,10 @@
             "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
             "dev": true
         },
-        "node_modules/date-fns": {
-            "version": "2.29.3",
-            "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
-            "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==",
-            "engines": {
-                "node": ">=0.11"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/date-fns"
-            }
+        "node_modules/dataloader": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.1.0.tgz",
+            "integrity": "sha512-qTcEYLen3r7ojZNgVUaRggOI+KM7jrKxXeSHhogh/TWxYMeONEMqY+hmkobiYQozsGIyg9OYVzO4ZIfoB4I0pQ=="
         },
         "node_modules/debug": {
             "version": "4.3.4",
@@ -3041,7 +3079,6 @@
             "version": "2.12.6",
             "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
             "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.1.0"
             },
@@ -3930,7 +3967,6 @@
             "version": "2.29.4",
             "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
             "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
-            "peer": true,
             "engines": {
                 "node": "*"
             }
@@ -6479,6 +6515,46 @@
                 "use-debounce": "^5.0.3"
             }
         },
+        "@searchkit/schema": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@searchkit/schema/-/schema-3.0.0.tgz",
+            "integrity": "sha512-JUBLhIGLxpsroVv+7ad2hfZTFboDO+isXS+60cYocWI2hl48fR3ZQuZ5ZErH6kADPOg6PRT1t6UyLRpUYX4Vrg==",
+            "requires": {
+                "@elastic/elasticsearch": "7.13.0",
+                "@searchkit/sdk": "^3.0.0",
+                "dataloader": "^2.0.0",
+                "graphql-tag": "^2.10.3",
+                "lodash": "^4.17.21"
+            },
+            "dependencies": {
+                "@elastic/elasticsearch": {
+                    "version": "7.13.0",
+                    "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-7.13.0.tgz",
+                    "integrity": "sha512-WgwLWo2p9P2tdqzBGX9fHeG8p5IOTXprXNTECQG2mJ7z9n93N5AFBJpEw4d35tWWeCWi9jI13A2wzQZH7XZ/xw==",
+                    "requires": {
+                        "debug": "^4.3.1",
+                        "hpagent": "^0.1.1",
+                        "ms": "^2.1.3",
+                        "secure-json-parse": "^2.4.0"
+                    }
+                },
+                "hpagent": {
+                    "version": "0.1.2",
+                    "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-0.1.2.tgz",
+                    "integrity": "sha512-ePqFXHtSQWAFXYmj+JtOTHr84iNrII4/QRlAAPPE+zqnKy4xJo7Ie1Y4kC7AdB+LxLxSTTzBMASsEcy0q8YyvQ=="
+                }
+            }
+        },
+        "@searchkit/sdk": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@searchkit/sdk/-/sdk-3.0.0.tgz",
+            "integrity": "sha512-cWtP5T2+xonPhnwDmda6+RQWvGBg0bigCmZLm+fPPJOymEIug5LQF1s0abcWlwDuXhNnMqiCdk/x2ZUJpt2xTA==",
+            "requires": {
+                "@elastic/elasticsearch-types": "npm:@elastic/elasticsearch@^8.2.1",
+                "agentkeepalive": "^4.1.3",
+                "lodash": "^4.17.21"
+            }
+        },
         "@types/chroma-js": {
             "version": "2.1.4",
             "resolved": "https://registry.npmjs.org/@types/chroma-js/-/chroma-js-2.1.4.tgz",
@@ -7021,10 +7097,10 @@
             "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
             "dev": true
         },
-        "date-fns": {
-            "version": "2.29.3",
-            "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
-            "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA=="
+        "dataloader": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.1.0.tgz",
+            "integrity": "sha512-qTcEYLen3r7ojZNgVUaRggOI+KM7jrKxXeSHhogh/TWxYMeONEMqY+hmkobiYQozsGIyg9OYVzO4ZIfoB4I0pQ=="
         },
         "debug": {
             "version": "4.3.4",
@@ -7983,7 +8059,6 @@
             "version": "2.12.6",
             "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
             "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
-            "peer": true,
             "requires": {
                 "tslib": "^2.1.0"
             }
@@ -8607,8 +8682,7 @@
         "moment": {
             "version": "2.29.4",
             "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-            "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
-            "peer": true
+            "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
         },
         "ms": {
             "version": "2.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
                 "@elastic/eui": "^34.6.0",
                 "@searchkit/client": "^3.0.0",
                 "@searchkit/elastic-ui": "^3.0.0",
+                "date-fns": "^2.29.3",
                 "react": "^16.14.0",
                 "react-dom": "^16.14.0",
                 "react-router-dom": "^6.4.2"
@@ -1621,6 +1622,18 @@
             "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
             "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
             "dev": true
+        },
+        "node_modules/date-fns": {
+            "version": "2.29.3",
+            "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
+            "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==",
+            "engines": {
+                "node": ">=0.11"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/date-fns"
+            }
         },
         "node_modules/debug": {
             "version": "4.3.4",
@@ -7007,6 +7020,11 @@
             "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
             "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
             "dev": true
+        },
+        "date-fns": {
+            "version": "2.29.3",
+            "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
+            "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA=="
         },
         "debug": {
             "version": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
         "@elastic/eui": "^34.6.0",
         "@searchkit/client": "^3.0.0",
         "@searchkit/elastic-ui": "^3.0.0",
-        "date-fns": "^2.29.3",
+        "@searchkit/schema": "^3.0.0",
+        "moment": "^2.29.4",
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
         "react-router-dom": "^6.4.2"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
         "@elastic/eui": "^34.6.0",
         "@searchkit/client": "^3.0.0",
         "@searchkit/elastic-ui": "^3.0.0",
+        "date-fns": "^2.29.3",
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
         "react-router-dom": "^6.4.2"

--- a/src/Root.jsx
+++ b/src/Root.jsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { Outlet } from "react-router-dom";
+import Navigation from "./components/Navigation";
+
+/**
+ * Root component containing all other site components, except ErrorPage.
+ *
+ * @returns {React.Component} React component.
+ */
+export function Root() {
+    return (
+        <>
+            <Navigation />
+            <Outlet />
+        </>
+    );
+}

--- a/src/assets/index.css
+++ b/src/assets/index.css
@@ -1,8 +1,5 @@
 :root {
   font-weight: 400;
-
-  color-scheme: light dark;
-
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;

--- a/src/components/DateRangeFacet.jsx
+++ b/src/components/DateRangeFacet.jsx
@@ -1,0 +1,91 @@
+import React, { useState, useEffect } from "react";
+import { EuiTitle, EuiDatePickerRange, EuiDatePicker } from "@elastic/eui";
+import { useSearchkit } from "@searchkit/client";
+import moment from "moment";
+
+/**
+ * DateRange facet display component, adapted from @searchkit/elastic-ui but with the
+ * ability to use minimum and maximum date aggregations across the dataset.
+ *
+ * @param {object} props React functional component props
+ * @param {object} props.data Results from ElasticSearch, which should include min and max date
+ * aggregations.
+ * @param {object} props.facet Facet Schema object returned from Searchkit
+ * @param {boolean} props.loading Loading indicator boolean
+ * @returns {React.Component} Date range React component
+ */
+function DateRangeFacet({ data, facet, loading }) {
+    // adapted from @searchkit/elastic-ui
+    const api = useSearchkit();
+    const selectedOptions = api.getFiltersByIdentifier(facet.identifier);
+    const selectedOption = selectedOptions && selectedOptions[0];
+    const [startDate, setStartDate] = useState(null);
+    const [endDate, setEndDate] = useState(null);
+
+    useEffect(() => {
+        if (startDate && endDate) {
+            if (selectedOption) {
+                api.removeFilter(selectedOption);
+            }
+            api.addFilter({
+                identifier: facet.identifier,
+                dateMin: startDate.toISOString(),
+                dateMax: endDate.toISOString(),
+            });
+            api.search();
+        }
+    }, [startDate, endDate]);
+
+    // get min and max date facet values
+    const minDate = data?.facets?.find((f) => f.identifier === "min_date")?.value || null;
+    const maxDate = data?.facets?.find((f) => f.identifier === "max_date")?.value || null;
+
+    const currentMinValue = moment(
+        startDate || selectedOption?.dateMin || minDate,
+    );
+    const currentMaxValue = moment(
+        endDate || selectedOption?.dateMax || maxDate,
+    );
+
+    return (
+        <>
+            <EuiTitle size="xxs">
+                <h3>{facet.label}</h3>
+            </EuiTitle>
+            <EuiDatePickerRange
+                startDateControl={(
+                    <EuiDatePicker
+                        isLoading={loading}
+                        selected={startDate}
+                        onChange={setStartDate}
+                        startDate={startDate}
+                        value={currentMinValue.format("L")}
+                        endDate={endDate}
+                        placeholder="from"
+                        isInvalid={startDate > endDate}
+                        aria-label="Start date"
+                        openToDate={currentMinValue}
+                    />
+                )}
+                endDateControl={(
+                    <EuiDatePicker
+                        isLoading={loading}
+                        selected={endDate}
+                        onChange={setEndDate}
+                        startDate={startDate}
+                        value={currentMaxValue.format("L")}
+                        endDate={endDate}
+                        isInvalid={startDate > endDate}
+                        aria-label="End date"
+                        placeholder="to"
+                        openToDate={currentMaxValue}
+                    />
+                )}
+            />
+        </>
+    );
+}
+
+DateRangeFacet.DISPLAY = "CustomDateFacet";
+
+export default DateRangeFacet;

--- a/src/components/DateRangeFilter.jsx
+++ b/src/components/DateRangeFilter.jsx
@@ -1,0 +1,33 @@
+import { EuiButton, EuiFlexItem } from "@elastic/eui";
+import { useSearchkit } from "@searchkit/client";
+import { formatDate } from "../pages/common";
+
+// eslint-disable-next-line jsdoc/require-param, jsdoc/require-returns
+/**
+ * adapted from @searchkit/elastic-ui
+ * https://github.com/searchkit/searchkit/blob/a67420cb1e16d2a459f473c904cde10b3cfd5858/packages/searchkit-elastic-ui/src/SelectedFilters/index.tsx#L25-L44
+ */
+function DateRangeFilter({ filter, loading }) {
+    const api = useSearchkit();
+    const rangeString = `${filter.label}: ${formatDate(
+        filter.dateMin,
+    )} – ${formatDate(filter.dateMax)}`;
+
+    return (
+        <EuiFlexItem grow={false}>
+            <EuiButton
+                onClick={() => {
+                    api.removeFilter(filter);
+                    api.search();
+                }}
+                iconSide="right"
+                iconType="cross"
+                isLoading={loading}
+            >
+                {rangeString}
+            </EuiButton>
+        </EuiFlexItem>
+    );
+}
+
+export default DateRangeFilter;

--- a/src/components/LettersResults.css
+++ b/src/components/LettersResults.css
@@ -1,0 +1,6 @@
+th:first-child {
+    width: 3%;
+}
+th:not(:first-child) {
+    width: 33%;
+}

--- a/src/components/LettersResults.jsx
+++ b/src/components/LettersResults.jsx
@@ -1,7 +1,7 @@
 import "./LettersResults.css";
 
 /**
- * List of results for the Entities search view.
+ * List of results for the Letters search view.
  *
  * @param {object} props Props for React functional component
  * @param {object} props.data Data returned by ElasticSearch

--- a/src/components/LettersResults.jsx
+++ b/src/components/LettersResults.jsx
@@ -1,0 +1,59 @@
+import "./LettersResults.css";
+
+/**
+ * List of results for the Entities search view.
+ *
+ * @param {object} props Props for React functional component
+ * @param {object} props.data Data returned by ElasticSearch
+ * @param {number} props.offset Offset of results for current page
+ * @returns Populated results list React component
+ */
+function LettersResults({ data, offset }) {
+    return (
+        <table>
+            <thead>
+                <tr>
+                    <th aria-label="index">#</th>
+                    <th>Recipient</th>
+                    <th>Repository</th>
+                    <th>Date</th>
+                </tr>
+            </thead>
+            <tbody>
+                {data?.hits?.items?.map((letter, idx) => {
+                    const date = new Date(letter?.fields?.date);
+                    const month = new Intl.DateTimeFormat("en-US", {
+                        month: "long",
+                    }).format(date);
+                    const dateString = `${date.getDate()} ${month} ${date.getFullYear()}`;
+                    return (
+                        <tr key={letter.id} id={letter.id}>
+                            <td>{idx + 1 + (offset || 0)}</td>
+                            <td>
+                                <ul>
+                                    {letter?.fields?.recipients?.map(
+                                        (recipient) => (
+                                            <li key={recipient}>{recipient}</li>
+                                        ),
+                                    )}
+                                </ul>
+                            </td>
+                            <td>
+                                <ul>
+                                    {letter?.fields?.repositories?.map(
+                                        (repository) => (
+                                            <li>{repository}</li>
+                                        ),
+                                    )}
+                                </ul>
+                            </td>
+                            <td>{dateString}</td>
+                        </tr>
+                    );
+                })}
+            </tbody>
+        </table>
+    );
+}
+
+export default LettersResults;

--- a/src/components/LettersResults.jsx
+++ b/src/components/LettersResults.jsx
@@ -42,7 +42,9 @@ function LettersResults({ data, offset }) {
                                 <ul>
                                     {letter?.fields?.repositories?.map(
                                         (repository) => (
-                                            <li>{repository}</li>
+                                            <li key={repository}>
+                                                {repository}
+                                            </li>
                                         ),
                                     )}
                                 </ul>

--- a/src/components/LettersResults.jsx
+++ b/src/components/LettersResults.jsx
@@ -1,3 +1,4 @@
+import { formatDate } from "../pages/common";
 import "./LettersResults.css";
 
 /**
@@ -21,11 +22,7 @@ function LettersResults({ data, offset }) {
             </thead>
             <tbody>
                 {data?.hits?.items?.map((letter, idx) => {
-                    const date = new Date(letter?.fields?.date);
-                    const month = new Intl.DateTimeFormat("en-US", {
-                        month: "long",
-                    }).format(date);
-                    const dateString = `${date.getDate()} ${month} ${date.getFullYear()}`;
+                    const dateString = formatDate(letter?.fields?.date);
                     return (
                         <tr key={letter.id} id={letter.id}>
                             <td>{idx + 1 + (offset || 0)}</td>

--- a/src/components/ListFacet.css
+++ b/src/components/ListFacet.css
@@ -1,5 +1,17 @@
-.facet-group .facet-button {
+.list-facet .facet-group .facet-button {
+    min-height: 28px;
     height: 28px;
     margin-top: 0;
     margin-bottom: 0;
+    margin-right: 5px;
+}
+.list-facet:not(:first-child) {
+    margin-top: 1rem;
+}
+.list-facet h3 {
+    margin-bottom: 0.25rem;
+}
+.list-facet .facet-group {
+    overflow-y: auto;
+    max-height: 400px;
 }

--- a/src/components/ListFacet.jsx
+++ b/src/components/ListFacet.jsx
@@ -51,12 +51,12 @@ function ListFacet({ facet, loading }) {
     }
 
     return (
-        <>
+        <div className="list-facet">
             <EuiTitle size="xxs">
                 <h3>{facet.label}</h3>
             </EuiTitle>
             <EuiFacetGroup className="facet-group">{entries}</EuiFacetGroup>
-        </>
+        </div>
     );
 }
 

--- a/src/components/ListFacet.jsx
+++ b/src/components/ListFacet.jsx
@@ -1,6 +1,7 @@
 import { Fragment, useRef, useEffect } from "react";
 import { EuiFacetButton, EuiFacetGroup, EuiTitle } from "@elastic/eui";
 import { useSearchkit, FilterLink } from "@searchkit/client";
+import { volumeLabels } from "../pages/common";
 import "./ListFacet.css";
 
 /**
@@ -22,32 +23,43 @@ function ListFacet({ facet, loading }) {
     }, [facet?.entries]);
 
     const entries = facet?.entries?.map((entry, i) => {
-        const label = entry.label.toString().trim().replaceAll("_", " ");
-        return label && (
-            <EuiFacetButton
-                className="facet-button"
-                key={entry.label}
-                quantity={entry.count}
-                isSelected={api.isFilterSelected({
-                    identifier: facet.identifier,
-                    value: entry.label,
-                })}
-                isLoading={loading}
-                onClick={(e) => {
-                    ref.current[i].onClick(e);
-                }}
-            >
-                <FilterLink
-                    ref={(el) => {
-                        ref.current[i] = el;
+        let label = entry.label.toString().trim().replaceAll("_", " ");
+        // special handling for volume labels
+        if (
+            label
+            && facet.identifier === "volume"
+            && Object.keys(volumeLabels).includes(label)
+        ) {
+            label = volumeLabels[label];
+        }
+        return (
+            label && (
+                <EuiFacetButton
+                    className="facet-button"
+                    key={entry.label}
+                    quantity={entry.count}
+                    isSelected={api.isFilterSelected({
+                        identifier: facet.identifier,
+                        value: entry.label,
+                    })}
+                    isLoading={loading}
+                    onClick={(e) => {
+                        ref.current[i].onClick(e);
                     }}
-                    filter={{ identifier: facet.identifier, value: entry.label }}
                 >
-                    <span className="capital-label">
-                        {label}
-                    </span>
-                </FilterLink>
-            </EuiFacetButton>
+                    <FilterLink
+                        ref={(el) => {
+                            ref.current[i] = el;
+                        }}
+                        filter={{
+                            identifier: facet.identifier,
+                            value: entry.label,
+                        }}
+                    >
+                        <span className="capital-label">{label}</span>
+                    </FilterLink>
+                </EuiFacetButton>
+            )
         );
     });
 

--- a/src/components/ListFacet.jsx
+++ b/src/components/ListFacet.jsx
@@ -60,4 +60,7 @@ function ListFacet({ facet, loading }) {
     );
 }
 
+// Disambiguate from Searchkit builtin ListFacet
+ListFacet.DISPLAY = "CustomListFacet";
+
 export default ListFacet;

--- a/src/components/ListFacet.jsx
+++ b/src/components/ListFacet.jsx
@@ -21,33 +21,35 @@ function ListFacet({ facet, loading }) {
         ref.current = ref.current.slice(0, facet?.entries.length);
     }, [facet?.entries]);
 
-    const entries = facet?.entries?.map((entry, i) => (
-        <EuiFacetButton
-            className="facet-button"
-            key={entry.label}
-            quantity={entry.count}
-            isSelected={api.isFilterSelected({
-                identifier: facet.identifier,
-                value: entry.label,
-            })}
-            isLoading={loading}
-            onClick={(e) => {
-                ref.current[i].onClick(e);
-            }}
-        >
-            <FilterLink
-                ref={(el) => {
-                    ref.current[i] = el;
+    const entries = facet?.entries?.map((entry, i) => {
+        const label = entry.label.toString().trim().replaceAll("_", " ");
+        return label && (
+            <EuiFacetButton
+                className="facet-button"
+                key={entry.label}
+                quantity={entry.count}
+                isSelected={api.isFilterSelected({
+                    identifier: facet.identifier,
+                    value: entry.label,
+                })}
+                isLoading={loading}
+                onClick={(e) => {
+                    ref.current[i].onClick(e);
                 }}
-                filter={{ identifier: facet.identifier, value: entry.label }}
             >
-                <span className="capital-label">
-                    {entry.label.toString().trim().replaceAll("_", " ")
-                        || "[blank]"}
-                </span>
-            </FilterLink>
-        </EuiFacetButton>
-    ));
+                <FilterLink
+                    ref={(el) => {
+                        ref.current[i] = el;
+                    }}
+                    filter={{ identifier: facet.identifier, value: entry.label }}
+                >
+                    <span className="capital-label">
+                        {label}
+                    </span>
+                </FilterLink>
+            </EuiFacetButton>
+        );
+    });
 
     if (!facet) {
         return null;

--- a/src/components/ListFacet.jsx
+++ b/src/components/ListFacet.jsx
@@ -41,7 +41,7 @@ function ListFacet({ facet, loading }) {
                 }}
                 filter={{ identifier: facet.identifier, value: entry.label }}
             >
-                {entry.label.toString().replaceAll("_", " ")}
+                {entry.label.toString().trim().replaceAll("_", " ") || "[blank]"}
             </FilterLink>
         </EuiFacetButton>
     ));

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -5,33 +5,52 @@ import {
     EuiHeaderLinks,
     EuiHeaderLink,
 } from "@elastic/eui";
+import { NavLink } from "react-router-dom";
 
 /**
  * Site navigation functional component.
- * TODO: - Use href on EuiHeaderLink to point to actual routes
- *       - Use isActive conditionally
- *       - Update style for site name
+ * TODO: - Update style for site name
  *
  * @returns React component
  */
 function Navigation() {
     return (
-        <EuiHeader>
-            <EuiHeaderSection>
-                <EuiHeaderSectionItem border="none">
-                    <EuiHeaderLinks>
-                        <EuiHeaderLink>Samuel Beckett Letters</EuiHeaderLink>
-                    </EuiHeaderLinks>
-                </EuiHeaderSectionItem>
-                <EuiHeaderSectionItem border="none">
-                    <EuiHeaderLinks>
-                        <EuiHeaderLink>About</EuiHeaderLink>
-                        <EuiHeaderLink>Search Letters</EuiHeaderLink>
-                        <EuiHeaderLink isActive>Search Entities</EuiHeaderLink>
-                    </EuiHeaderLinks>
-                </EuiHeaderSectionItem>
-            </EuiHeaderSection>
-        </EuiHeader>
+        <header>
+            <EuiHeader>
+                <EuiHeaderSection>
+                    <EuiHeaderSectionItem border="none">
+                        <EuiHeaderLinks>
+                            <NavLink to="/" end>
+                                <EuiHeaderLink>
+                                    Samuel Beckett Letters
+                                </EuiHeaderLink>
+                            </NavLink>
+                        </EuiHeaderLinks>
+                    </EuiHeaderSectionItem>
+                    <EuiHeaderSectionItem border="none">
+                        <EuiHeaderLinks>
+                            <NavLink to="/about">
+                                <EuiHeaderLink>About</EuiHeaderLink>
+                            </NavLink>
+                            <NavLink to="/letters">
+                                {({ isActive }) => (
+                                    <EuiHeaderLink isActive={isActive}>
+                                        Search Letters
+                                    </EuiHeaderLink>
+                                )}
+                            </NavLink>
+                            <NavLink to="/entities">
+                                {({ isActive }) => (
+                                    <EuiHeaderLink isActive={isActive}>
+                                        Search Entities
+                                    </EuiHeaderLink>
+                                )}
+                            </NavLink>
+                        </EuiHeaderLinks>
+                    </EuiHeaderSectionItem>
+                </EuiHeaderSection>
+            </EuiHeader>
+        </header>
     );
 }
 

--- a/src/components/ValueFilter.jsx
+++ b/src/components/ValueFilter.jsx
@@ -1,6 +1,7 @@
 import { EuiButton, EuiFlexItem } from "@elastic/eui";
 import { FilterLink } from "@searchkit/client";
 import { useRef } from "react";
+import { volumeLabels } from "../pages/common";
 
 // eslint-disable-next-line jsdoc/require-param, jsdoc/require-returns
 /**
@@ -9,6 +10,15 @@ import { useRef } from "react";
  */
 function ValueFilter({ filter, loading }) {
     const ref = useRef();
+    let valueLabel = filter.value;
+    // special handling for volume labels
+    if (
+        filter.value
+        && filter.identifier === "volume"
+        && Object.keys(volumeLabels).includes(filter.value)
+    ) {
+        valueLabel = volumeLabels[filter.value];
+    }
     return (
         <EuiFlexItem grow={false}>
             <EuiButton
@@ -20,7 +30,7 @@ function ValueFilter({ filter, loading }) {
                 }}
             >
                 <FilterLink ref={ref} filter={filter}>
-                    {`${filter.label}: ${filter.value}`}
+                    {`${filter.label}: ${valueLabel}`}
                 </FilterLink>
             </EuiButton>
         </EuiFlexItem>

--- a/src/components/ValueFilter.jsx
+++ b/src/components/ValueFilter.jsx
@@ -1,0 +1,30 @@
+import { EuiButton, EuiFlexItem } from "@elastic/eui";
+import { FilterLink } from "@searchkit/client";
+import { useRef } from "react";
+
+// eslint-disable-next-line jsdoc/require-param, jsdoc/require-returns
+/**
+ * copied directly from @searchkit/elastic-ui; needed, but not exported!
+ * https://github.com/searchkit/searchkit/blob/a67420cb1e16d2a459f473c904cde10b3cfd5858/packages/searchkit-elastic-ui/src/SelectedFilters/index.tsx#L46
+ */
+function ValueFilter({ filter, loading }) {
+    const ref = useRef();
+    return (
+        <EuiFlexItem grow={false}>
+            <EuiButton
+                iconSide="right"
+                iconType="cross"
+                isLoading={loading}
+                onClick={(e) => {
+                    ref.current.onClick(e);
+                }}
+            >
+                <FilterLink ref={ref} filter={filter}>
+                    {`${filter.label}: ${filter.value}`}
+                </FilterLink>
+            </EuiButton>
+        </EuiFlexItem>
+    );
+}
+
+export default ValueFilter;

--- a/src/components/withSearchRouting.jsx
+++ b/src/components/withSearchRouting.jsx
@@ -1,6 +1,6 @@
 import { withSearchkitRouting } from "@searchkit/client";
 import React from "react";
-import { format } from "date-fns";
+import moment from "moment";
 
 /**
  * Higher-order component (HOC) for Searchkit routing. Just acts as a module for configuring
@@ -30,10 +30,10 @@ function withSearchRouting(component) {
             // date filter is formatted differently
             if (filter.dateMin || filter.dateMax) {
                 routeState.dateMin = filter.dateMin
-                    ? format(new Date(filter.dateMin), "yyyy-MM-dd")
+                    ? moment(new Date(filter.dateMin)).format("yyyy-MM-DD")
                     : undefined;
                 routeState.dateMax = filter.dateMax
-                    ? format(new Date(filter.dateMax), "yyyy-MM-dd")
+                    ? moment(new Date(filter.dateMax)).format("yyyy-MM-DD")
                     : undefined;
             } else if (filter.value) {
                 if (Object.hasOwn(routeState, filter.identifier)) {

--- a/src/components/withSearchRouting.jsx
+++ b/src/components/withSearchRouting.jsx
@@ -1,5 +1,6 @@
 import { withSearchkitRouting } from "@searchkit/client";
 import React from "react";
+import { format } from "date-fns";
 
 /**
  * Higher-order component (HOC) for Searchkit routing. Just acts as a module for configuring
@@ -26,10 +27,20 @@ function withSearchRouting(component) {
         };
         searchState.filters.forEach((filter) => {
             // simplify filter representation
-            if (Object.hasOwn(routeState, filter.identifier)) {
-                routeState[filter.identifier].push(filter.value);
-            } else {
-                routeState[filter.identifier] = [filter.value];
+            // date filter is formatted differently
+            if (filter.dateMin || filter.dateMax) {
+                routeState.dateMin = filter.dateMin
+                    ? format(new Date(filter.dateMin), "yyyy-MM-dd")
+                    : undefined;
+                routeState.dateMax = filter.dateMax
+                    ? format(new Date(filter.dateMax), "yyyy-MM-dd")
+                    : undefined;
+            } else if (filter.value) {
+                if (Object.hasOwn(routeState, filter.identifier)) {
+                    routeState[filter.identifier].push(filter.value);
+                } else {
+                    routeState[filter.identifier] = [filter.value];
+                }
             }
         });
         // transform into the object to pass to createURL (adapted from Searchkit docs)
@@ -65,7 +76,16 @@ function withSearchRouting(component) {
         };
         // get filters state back into format expected by Searchkit
         Object.entries(route)
-            .filter(([key]) => !["query", "sort", "size", "from"].includes(key))
+            .filter(
+                ([key, _val]) => ![
+                    "query", // only process filters, not query/sort/size/from
+                    "sort",
+                    "size",
+                    "from",
+                    "dateMin", // handle date filters separately
+                    "dateMax",
+                ].includes(key),
+            )
             .forEach(([identifier, val]) => {
                 // map each value of each filter to objects
                 if (Array.isArray(val)) {
@@ -75,8 +95,17 @@ function withSearchRouting(component) {
                             value,
                         });
                     });
+                } else {
+                    searchState.filters.push({
+                        identifier,
+                        value: val,
+                    });
                 }
             });
+        if (route.dateMin || route.dateMax) {
+            const { dateMin, dateMax } = route;
+            searchState.filters.push({ identifier: "date", dateMin, dateMax });
+        }
         return searchState;
     }
 

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,18 +1,33 @@
 import React from "react";
 import * as ReactDOM from "react-dom";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { RouterProvider, createBrowserRouter } from "react-router-dom";
 import EntitiesSearch from "./pages/EntitiesSearch";
-import { LettersSearchPage } from "./pages";
+import { LettersSearchPage, ErrorPage } from "./pages";
+import { Root } from "./Root";
 import "./assets/index.css";
+
+const router = createBrowserRouter([
+    {
+        path: "/",
+        element: <Root />,
+        errorElement: <ErrorPage />,
+        children: [
+            // { index: true, element: <HomePage /> },
+            {
+                path: "entities",
+                element: <EntitiesSearch />,
+            },
+            {
+                path: "letters",
+                element: <LettersSearchPage />,
+            },
+        ],
+    },
+]);
 
 ReactDOM.render(
     <React.StrictMode>
-        <BrowserRouter>
-            <Routes>
-                <Route path="/" element={<EntitiesSearch />} />
-                <Route path="/letters" element={<LettersSearchPage />} />
-            </Routes>
-        </BrowserRouter>
+        <RouterProvider router={router} />
     </React.StrictMode>,
     document.getElementById("root"),
 );

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import * as ReactDOM from "react-dom";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import EntitiesSearch from "./pages/EntitiesSearch";
+import { LettersSearchPage } from "./pages";
 import "./assets/index.css";
 
 ReactDOM.render(
@@ -9,6 +10,7 @@ ReactDOM.render(
         <BrowserRouter>
             <Routes>
                 <Route path="/" element={<EntitiesSearch />} />
+                <Route path="/letters" element={<LettersSearchPage />} />
             </Routes>
         </BrowserRouter>
     </React.StrictMode>,

--- a/src/pages/EntitiesSearch.jsx
+++ b/src/pages/EntitiesSearch.jsx
@@ -33,7 +33,6 @@ import { icon as EuiIconCross } from "@elastic/eui/es/components/icon/assets/cro
 import { icon as EuiIconSearch } from "@elastic/eui/es/components/icon/assets/search";
 
 import EntitiesResults from "../components/EntitiesResults";
-import Navigation from "../components/Navigation";
 import { getEntitiesQuery } from "../utils/query";
 import "./EntitiesSearch.css";
 import ListFacet from "../components/ListFacet";
@@ -104,62 +103,57 @@ function EntitiesSearch() {
     const variables = useSearchkitVariables();
     const { results, loading } = useSearchkitSDK(config, variables);
     return (
-        <>
-            <header>
-                <Navigation />
-            </header>
-            <main>
-                <EuiPage paddingSize="l">
-                    <aside>
-                        <EuiPageSideBar>
-                            <SearchBar loading={loading} />
-                            <EuiHorizontalRule margin="m" />
-                            {results?.facets.map((facet) => (
-                                <ListFacet
-                                    key={facet.identifier}
-                                    facet={facet}
+        <main>
+            <EuiPage paddingSize="l">
+                <aside>
+                    <EuiPageSideBar>
+                        <SearchBar loading={loading} />
+                        <EuiHorizontalRule margin="m" />
+                        {results?.facets.map((facet) => (
+                            <ListFacet
+                                key={facet.identifier}
+                                facet={facet}
+                                loading={loading}
+                            />
+                        ))}
+                    </EuiPageSideBar>
+                </aside>
+                <EuiPageBody component="section">
+                    <EuiPageHeader>
+                        <EuiPageHeaderSection>
+                            <EuiTitle size="l">
+                                <SelectedFilters
+                                    data={results}
                                     loading={loading}
                                 />
-                            ))}
-                        </EuiPageSideBar>
-                    </aside>
-                    <EuiPageBody component="section">
-                        <EuiPageHeader>
-                            <EuiPageHeaderSection>
-                                <EuiTitle size="l">
-                                    <SelectedFilters
-                                        data={results}
-                                        loading={loading}
-                                    />
+                            </EuiTitle>
+                        </EuiPageHeaderSection>
+                        <EuiPageHeaderSection>
+                            <ResetSearchButton loading={loading} />
+                        </EuiPageHeaderSection>
+                    </EuiPageHeader>
+                    <EuiPageContent>
+                        <EuiPageContentHeader>
+                            <EuiPageContentHeaderSection>
+                                <EuiTitle size="s">
+                                    <h2>
+                                        {results?.summary.total}
+                                        {" "}
+                                        Results
+                                    </h2>
                                 </EuiTitle>
-                            </EuiPageHeaderSection>
-                            <EuiPageHeaderSection>
-                                <ResetSearchButton loading={loading} />
-                            </EuiPageHeaderSection>
-                        </EuiPageHeader>
-                        <EuiPageContent>
-                            <EuiPageContentHeader>
-                                <EuiPageContentHeaderSection>
-                                    <EuiTitle size="s">
-                                        <h2>
-                                            {results?.summary.total}
-                                            {" "}
-                                            Results
-                                        </h2>
-                                    </EuiTitle>
-                                </EuiPageContentHeaderSection>
-                            </EuiPageContentHeader>
-                            <EuiPageContentBody>
-                                <EntitiesResults data={results} />
-                                <EuiFlexGroup justifyContent="spaceAround">
-                                    <Pagination data={results} />
-                                </EuiFlexGroup>
-                            </EuiPageContentBody>
-                        </EuiPageContent>
-                    </EuiPageBody>
-                </EuiPage>
-            </main>
-        </>
+                            </EuiPageContentHeaderSection>
+                        </EuiPageContentHeader>
+                        <EuiPageContentBody>
+                            <EntitiesResults data={results} />
+                            <EuiFlexGroup justifyContent="spaceAround">
+                                <Pagination data={results} />
+                            </EuiFlexGroup>
+                        </EuiPageContentBody>
+                    </EuiPageContent>
+                </EuiPageBody>
+            </EuiPage>
+        </main>
     );
 }
 

--- a/src/pages/ErrorPage/ErrorPage.jsx
+++ b/src/pages/ErrorPage/ErrorPage.jsx
@@ -1,0 +1,46 @@
+import {
+    EuiPage,
+    EuiPageBody,
+    EuiPageContent,
+    EuiPageContentBody,
+    EuiPageHeader,
+    EuiPageHeaderSection,
+    EuiTitle,
+} from "@elastic/eui";
+import React from "react";
+import { useRouteError } from "react-router-dom";
+import Navigation from "../../components/Navigation";
+
+/**
+ * Page component for error handling.
+ *
+ * @returns {React.Component} React component containing error message
+ */
+export function ErrorPage() {
+    const error = useRouteError();
+    return (
+        <>
+            <Navigation />
+            <main>
+                <EuiPage paddingSize="l">
+                    <EuiPageBody component="section">
+                        <EuiPageHeader>
+                            <EuiPageHeaderSection>
+                                <EuiTitle size="m">
+                                    <h1>
+                                        {`${error.status} ${error.statusText}`}
+                                    </h1>
+                                </EuiTitle>
+                            </EuiPageHeaderSection>
+                        </EuiPageHeader>
+                        <EuiPageContent>
+                            <EuiPageContentBody>
+                                <p>This page could not be displayed.</p>
+                            </EuiPageContentBody>
+                        </EuiPageContent>
+                    </EuiPageBody>
+                </EuiPage>
+            </main>
+        </>
+    );
+}

--- a/src/pages/ErrorPage/index.js
+++ b/src/pages/ErrorPage/index.js
@@ -1,0 +1,1 @@
+export * from "./ErrorPage";

--- a/src/pages/LettersSearchPage/LettersSearchPage.jsx
+++ b/src/pages/LettersSearchPage/LettersSearchPage.jsx
@@ -6,10 +6,11 @@ import {
     withSearchkit,
 } from "@searchkit/client";
 import {
-    SearchBar,
-    ResetSearchButton,
-    SelectedFilters,
+    FacetsList,
     Pagination,
+    ResetSearchButton,
+    SearchBar,
+    SelectedFilters,
 } from "@searchkit/elastic-ui";
 import {
     EuiPage,
@@ -30,11 +31,13 @@ import { appendIconComponentCache } from "@elastic/eui/es/components/icon/icon";
 import { icon as EuiIconArrowLeft } from "@elastic/eui/es/components/icon/assets/arrow_left";
 import { icon as EuiIconArrowRight } from "@elastic/eui/es/components/icon/assets/arrow_right";
 import { icon as EuiIconCross } from "@elastic/eui/es/components/icon/assets/cross";
+import { icon as EuiIconCalendar } from "@elastic/eui/es/components/icon/assets/calendar";
 import { icon as EuiIconSearch } from "@elastic/eui/es/components/icon/assets/search";
 
 import { lettersSearchConfig } from "./lettersSearchConfig";
 import LettersResults from "../../components/LettersResults";
 import ListFacet from "../../components/ListFacet";
+import ValueFilter from "../../components/ValueFilter";
 import withSearchRouting from "../../components/withSearchRouting";
 import "../common/search.css";
 
@@ -43,6 +46,7 @@ import "../common/search.css";
 appendIconComponentCache({
     arrowLeft: EuiIconArrowLeft,
     arrowRight: EuiIconArrowRight,
+    calendar: EuiIconCalendar,
     cross: EuiIconCross,
     search: EuiIconSearch,
 });
@@ -58,6 +62,7 @@ function LettersSearch() {
         lettersSearchConfig,
         variables,
     );
+    const Facets = FacetsList([ListFacet]);
     return (
         <main>
             <EuiPage paddingSize="l">
@@ -65,13 +70,7 @@ function LettersSearch() {
                     <EuiPageSideBar>
                         <SearchBar loading={loading} />
                         <EuiHorizontalRule margin="m" />
-                        {results?.facets.map((facet) => (
-                            <ListFacet
-                                key={facet.identifier}
-                                facet={facet}
-                                loading={loading}
-                            />
-                        ))}
+                        <Facets data={results} loading={loading} />
                     </EuiPageSideBar>
                 </aside>
                 <EuiPageBody component="section">
@@ -81,6 +80,9 @@ function LettersSearch() {
                                 <SelectedFilters
                                     data={results}
                                     loading={loading}
+                                    customFilterComponents={{
+                                        CustomListFacet: ValueFilter,
+                                    }}
                                 />
                             </EuiTitle>
                         </EuiPageHeaderSection>

--- a/src/pages/LettersSearchPage/LettersSearchPage.jsx
+++ b/src/pages/LettersSearchPage/LettersSearchPage.jsx
@@ -1,0 +1,123 @@
+// eslint-disable-next-line import/no-unresolved
+import { useSearchkitSDK } from "@ecds/searchkit-sdk/src/react-hooks";
+import { useSearchkitVariables, withSearchkit } from "@searchkit/client";
+import {
+    SearchBar,
+    ResetSearchButton,
+    SelectedFilters,
+    Pagination,
+} from "@searchkit/elastic-ui";
+import {
+    EuiPage,
+    EuiPageBody,
+    EuiPageContent,
+    EuiPageContentBody,
+    EuiPageContentHeader,
+    EuiPageContentHeaderSection,
+    EuiPageHeader,
+    EuiPageHeaderSection,
+    EuiPageSideBar,
+    EuiTitle,
+    EuiHorizontalRule,
+    EuiFlexGroup,
+} from "@elastic/eui";
+import "@elastic/eui/dist/eui_theme_light.css";
+import { appendIconComponentCache } from "@elastic/eui/es/components/icon/icon";
+import { icon as EuiIconArrowLeft } from "@elastic/eui/es/components/icon/assets/arrow_left";
+import { icon as EuiIconArrowRight } from "@elastic/eui/es/components/icon/assets/arrow_right";
+import { icon as EuiIconCross } from "@elastic/eui/es/components/icon/assets/cross";
+import { icon as EuiIconSearch } from "@elastic/eui/es/components/icon/assets/search";
+
+import { lettersSearchConfig } from "./lettersSearchConfig";
+import LettersResults from "../../components/LettersResults";
+import ListFacet from "../../components/ListFacet";
+import Navigation from "../../components/Navigation";
+import withSearchRouting from "../../components/withSearchRouting";
+import "../common/search.css";
+
+// icon component cache required for dynamically imported EUI icons in Vite;
+// see https://github.com/elastic/eui/issues/5463
+appendIconComponentCache({
+    arrowLeft: EuiIconArrowLeft,
+    arrowRight: EuiIconArrowRight,
+    cross: EuiIconCross,
+    search: EuiIconSearch,
+});
+
+/**
+ * Letters search page.
+ *
+ * @returns React letters search page component
+ */
+function LettersSearch() {
+    const variables = useSearchkitVariables();
+    const { results, loading } = useSearchkitSDK(
+        lettersSearchConfig,
+        variables,
+    );
+    return (
+        <>
+            <header>
+                <Navigation />
+            </header>
+            <main>
+                <EuiPage paddingSize="l">
+                    <aside>
+                        <EuiPageSideBar>
+                            <SearchBar loading={loading} />
+                            <EuiHorizontalRule margin="m" />
+                            {results?.facets.map((facet) => (
+                                <ListFacet
+                                    key={facet.identifier}
+                                    facet={facet}
+                                    loading={loading}
+                                />
+                            ))}
+                        </EuiPageSideBar>
+                    </aside>
+                    <EuiPageBody component="section">
+                        <EuiPageHeader>
+                            <EuiPageHeaderSection>
+                                <EuiTitle size="l">
+                                    <SelectedFilters
+                                        data={results}
+                                        loading={loading}
+                                    />
+                                </EuiTitle>
+                            </EuiPageHeaderSection>
+                            <EuiPageHeaderSection>
+                                <ResetSearchButton loading={loading} />
+                            </EuiPageHeaderSection>
+                        </EuiPageHeader>
+                        <EuiPageContent>
+                            <EuiPageContentHeader>
+                                <EuiPageContentHeaderSection>
+                                    <EuiTitle size="s">
+                                        <h2>
+                                            {results?.summary.total}
+                                            {" "}
+                                            Results
+                                        </h2>
+                                    </EuiTitle>
+                                </EuiPageContentHeaderSection>
+                            </EuiPageContentHeader>
+                            <EuiPageContentBody>
+                                <LettersResults
+                                    data={results}
+                                    offset={variables?.page?.from}
+                                />
+                                <EuiFlexGroup justifyContent="spaceAround">
+                                    <Pagination data={results} />
+                                </EuiFlexGroup>
+                            </EuiPageContentBody>
+                        </EuiPageContent>
+                    </EuiPageBody>
+                </EuiPage>
+            </main>
+        </>
+    );
+}
+
+export const LettersSearchPage = withSearchkit(
+    withSearchRouting(LettersSearch),
+);

--- a/src/pages/LettersSearchPage/LettersSearchPage.jsx
+++ b/src/pages/LettersSearchPage/LettersSearchPage.jsx
@@ -75,7 +75,7 @@ function LettersSearch() {
                 </aside>
                 <EuiPageBody component="section">
                     <EuiPageHeader>
-                        <EuiPageHeaderSection>
+                        <EuiPageHeaderSection className="active-facet-group">
                             <EuiTitle size="l">
                                 <SelectedFilters
                                     data={results}

--- a/src/pages/LettersSearchPage/LettersSearchPage.jsx
+++ b/src/pages/LettersSearchPage/LettersSearchPage.jsx
@@ -6,7 +6,6 @@ import {
     withSearchkit,
 } from "@searchkit/client";
 import {
-    FacetsList,
     Pagination,
     ResetSearchButton,
     SearchBar,
@@ -25,6 +24,7 @@ import {
     EuiTitle,
     EuiHorizontalRule,
     EuiFlexGroup,
+    EuiSpacer,
 } from "@elastic/eui";
 import "@elastic/eui/dist/eui_theme_light.css";
 import { appendIconComponentCache } from "@elastic/eui/es/components/icon/icon";
@@ -38,6 +38,8 @@ import { lettersSearchConfig } from "./lettersSearchConfig";
 import LettersResults from "../../components/LettersResults";
 import ListFacet from "../../components/ListFacet";
 import ValueFilter from "../../components/ValueFilter";
+import DateRangeFacet from "../../components/DateRangeFacet";
+import DateRangeFilter from "../../components/DateRangeFilter";
 import withSearchRouting from "../../components/withSearchRouting";
 import "../common/search.css";
 
@@ -62,7 +64,6 @@ function LettersSearch() {
         lettersSearchConfig,
         variables,
     );
-    const Facets = FacetsList([ListFacet]);
     return (
         <main>
             <EuiPage paddingSize="l">
@@ -70,7 +71,21 @@ function LettersSearch() {
                     <EuiPageSideBar>
                         <SearchBar loading={loading} />
                         <EuiHorizontalRule margin="m" />
-                        <Facets data={results} loading={loading} />
+                        {results?.facets.filter((facet) => facet.display).map((facet) => {
+                            const Component = facet.display === "CustomDateFacet"
+                                ? DateRangeFacet
+                                : ListFacet;
+                            return (
+                                <div key={facet.identifier}>
+                                    <Component
+                                        data={results}
+                                        facet={facet}
+                                        loading={loading}
+                                    />
+                                    <EuiSpacer size="l" />
+                                </div>
+                            );
+                        })}
                     </EuiPageSideBar>
                 </aside>
                 <EuiPageBody component="section">
@@ -81,6 +96,7 @@ function LettersSearch() {
                                     data={results}
                                     loading={loading}
                                     customFilterComponents={{
+                                        CustomDateFacet: DateRangeFilter,
                                         CustomListFacet: ValueFilter,
                                     }}
                                 />

--- a/src/pages/LettersSearchPage/LettersSearchPage.jsx
+++ b/src/pages/LettersSearchPage/LettersSearchPage.jsx
@@ -31,7 +31,6 @@ import { icon as EuiIconSearch } from "@elastic/eui/es/components/icon/assets/se
 import { lettersSearchConfig } from "./lettersSearchConfig";
 import LettersResults from "../../components/LettersResults";
 import ListFacet from "../../components/ListFacet";
-import Navigation from "../../components/Navigation";
 import withSearchRouting from "../../components/withSearchRouting";
 import "../common/search.css";
 
@@ -56,65 +55,60 @@ function LettersSearch() {
         variables,
     );
     return (
-        <>
-            <header>
-                <Navigation />
-            </header>
-            <main>
-                <EuiPage paddingSize="l">
-                    <aside>
-                        <EuiPageSideBar>
-                            <SearchBar loading={loading} />
-                            <EuiHorizontalRule margin="m" />
-                            {results?.facets.map((facet) => (
-                                <ListFacet
-                                    key={facet.identifier}
-                                    facet={facet}
+        <main>
+            <EuiPage paddingSize="l">
+                <aside>
+                    <EuiPageSideBar>
+                        <SearchBar loading={loading} />
+                        <EuiHorizontalRule margin="m" />
+                        {results?.facets.map((facet) => (
+                            <ListFacet
+                                key={facet.identifier}
+                                facet={facet}
+                                loading={loading}
+                            />
+                        ))}
+                    </EuiPageSideBar>
+                </aside>
+                <EuiPageBody component="section">
+                    <EuiPageHeader>
+                        <EuiPageHeaderSection>
+                            <EuiTitle size="l">
+                                <SelectedFilters
+                                    data={results}
                                     loading={loading}
                                 />
-                            ))}
-                        </EuiPageSideBar>
-                    </aside>
-                    <EuiPageBody component="section">
-                        <EuiPageHeader>
-                            <EuiPageHeaderSection>
-                                <EuiTitle size="l">
-                                    <SelectedFilters
-                                        data={results}
-                                        loading={loading}
-                                    />
+                            </EuiTitle>
+                        </EuiPageHeaderSection>
+                        <EuiPageHeaderSection>
+                            <ResetSearchButton loading={loading} />
+                        </EuiPageHeaderSection>
+                    </EuiPageHeader>
+                    <EuiPageContent>
+                        <EuiPageContentHeader>
+                            <EuiPageContentHeaderSection>
+                                <EuiTitle size="s">
+                                    <h2>
+                                        {results?.summary.total}
+                                        {" "}
+                                        Results
+                                    </h2>
                                 </EuiTitle>
-                            </EuiPageHeaderSection>
-                            <EuiPageHeaderSection>
-                                <ResetSearchButton loading={loading} />
-                            </EuiPageHeaderSection>
-                        </EuiPageHeader>
-                        <EuiPageContent>
-                            <EuiPageContentHeader>
-                                <EuiPageContentHeaderSection>
-                                    <EuiTitle size="s">
-                                        <h2>
-                                            {results?.summary.total}
-                                            {" "}
-                                            Results
-                                        </h2>
-                                    </EuiTitle>
-                                </EuiPageContentHeaderSection>
-                            </EuiPageContentHeader>
-                            <EuiPageContentBody>
-                                <LettersResults
-                                    data={results}
-                                    offset={variables?.page?.from}
-                                />
-                                <EuiFlexGroup justifyContent="spaceAround">
-                                    <Pagination data={results} />
-                                </EuiFlexGroup>
-                            </EuiPageContentBody>
-                        </EuiPageContent>
-                    </EuiPageBody>
-                </EuiPage>
-            </main>
-        </>
+                            </EuiPageContentHeaderSection>
+                        </EuiPageContentHeader>
+                        <EuiPageContentBody>
+                            <LettersResults
+                                data={results}
+                                offset={variables?.page?.from}
+                            />
+                            <EuiFlexGroup justifyContent="spaceAround">
+                                <Pagination data={results} />
+                            </EuiFlexGroup>
+                        </EuiPageContentBody>
+                    </EuiPageContent>
+                </EuiPageBody>
+            </EuiPage>
+        </main>
     );
 }
 

--- a/src/pages/LettersSearchPage/LettersSearchPage.jsx
+++ b/src/pages/LettersSearchPage/LettersSearchPage.jsx
@@ -1,6 +1,10 @@
 // eslint-disable-next-line import/no-unresolved
 import { useSearchkitSDK } from "@ecds/searchkit-sdk/src/react-hooks";
-import { useSearchkitVariables, withSearchkit } from "@searchkit/client";
+import {
+    SearchkitClient,
+    useSearchkitVariables,
+    withSearchkit,
+} from "@searchkit/client";
 import {
     SearchBar,
     ResetSearchButton,
@@ -114,4 +118,5 @@ function LettersSearch() {
 
 export const LettersSearchPage = withSearchkit(
     withSearchRouting(LettersSearch),
+    () => new SearchkitClient({ itemsPerPage: 25 }),
 );

--- a/src/pages/LettersSearchPage/MinMaxDateFacet.js
+++ b/src/pages/LettersSearchPage/MinMaxDateFacet.js
@@ -1,0 +1,70 @@
+export class MinMaxDateFacet {
+    /**
+     * A facet used to aggregate the minimum or maximum date in the dataset.
+     *
+     * @param {object} config Configuration options
+     */
+    constructor(config) {
+        this.config = config;
+        this.excludeOwnFilters = true;
+    }
+
+    /**
+     * Identifier, which must be unique to facet if not configured.
+     *
+     * @returns {string} Identifier
+     */
+    getIdentifier() {
+        return this.config.identifier;
+    }
+
+    /**
+     * Label used for display, if displayed (it's not in our app).
+     *
+     * @returns {string} Label
+     */
+    getLabel() {
+        return this.config.label;
+    }
+
+    /**
+     * String "min" or "max" to determine which kind of aggregation this is
+     *
+     * @returns {string} The string "min" or "max"
+     */
+    getMinMax() {
+        return this.config.minMax;
+    }
+
+    /**
+     * The ElasticSearch aggregation query for the facet
+     *
+     * @returns {object} Aggregation query object
+     */
+    getAggregation() {
+        return {
+            [this.getIdentifier()]: {
+                [this.getMinMax()]: {
+                    field: this.config.field,
+                    format: "yyyy-MM-dd",
+                },
+            },
+        };
+    }
+
+    /**
+     * transform ES response into an object that matches the Facet Schema type
+     *
+     * @param {object} response ElasticSearch response object
+     * @returns {object} Facet Schema object, plus value field
+     */
+    transformResponse(response) {
+        return {
+            identifier: this.getIdentifier(),
+            label: this.getLabel(),
+            type: "CustomFacet",
+            display: this.config.display,
+            value: response.value_as_string,
+        };
+    }
+}

--- a/src/pages/LettersSearchPage/index.js
+++ b/src/pages/LettersSearchPage/index.js
@@ -1,0 +1,1 @@
+export * from "./LettersSearchPage";

--- a/src/pages/LettersSearchPage/lettersSearchConfig.js
+++ b/src/pages/LettersSearchPage/lettersSearchConfig.js
@@ -28,13 +28,30 @@ export const lettersSearchConfig = {
     },
     query: buildQuery({ analyzers, fields }),
     facets: [
+        // TODO: Add this facet (and modify searchkit if necessary) when vaild values are determined
+        // new RefinementSelectFacet({
+        //     field: "volume",
+        //     identifier: "volume",
+        //     label: "Published Volume",
+        //     multipleSelect: true,
+        //     order: "value",
+        //     size: 100,
+        // }),
         new RefinementSelectFacet({
             field: "language",
             identifier: "language",
             label: "Language",
             multipleSelect: true,
             order: "value",
-            size: 100, // Show at most 100 facets (there won't be that many!)
+            size: 100,
+        }),
+        new RefinementSelectFacet({
+            field: "repositories",
+            identifier: "repository",
+            label: "Repository",
+            multipleSelect: true,
+            order: "count",
+            size: 200,
         }),
     ],
     sortOptions: [

--- a/src/pages/LettersSearchPage/lettersSearchConfig.js
+++ b/src/pages/LettersSearchPage/lettersSearchConfig.js
@@ -1,4 +1,4 @@
-import { RefinementSelectFacet } from "@ecds/searchkit-sdk";
+import { DateRangeFacet, RefinementSelectFacet } from "@ecds/searchkit-sdk";
 import { buildQuery } from "../common/queryBuilder";
 
 // kewyord field names to search on
@@ -28,6 +28,11 @@ export const lettersSearchConfig = {
     },
     query: buildQuery({ analyzers, fields }),
     facets: [
+        new DateRangeFacet({
+            field: "date",
+            identifier: "date",
+            label: "Date",
+        }),
         // TODO: Add this facet (and modify searchkit if necessary) when vaild values are determined
         // new RefinementSelectFacet({
         //     field: "volume",

--- a/src/pages/LettersSearchPage/lettersSearchConfig.js
+++ b/src/pages/LettersSearchPage/lettersSearchConfig.js
@@ -44,6 +44,7 @@ export const lettersSearchConfig = {
             multipleSelect: true,
             order: "value",
             size: 100,
+            display: "CustomListFacet",
         }),
         new RefinementSelectFacet({
             field: "repositories",
@@ -52,6 +53,7 @@ export const lettersSearchConfig = {
             multipleSelect: true,
             order: "count",
             size: 200,
+            display: "CustomListFacet",
         }),
     ],
     sortOptions: [

--- a/src/pages/LettersSearchPage/lettersSearchConfig.js
+++ b/src/pages/LettersSearchPage/lettersSearchConfig.js
@@ -1,0 +1,61 @@
+import { RefinementSelectFacet } from "@ecds/searchkit-sdk";
+import { buildQuery } from "../common/queryBuilder";
+
+// kewyord field names to search on
+const fields = [
+    { name: "recipients", boost: 2 },
+    { name: "destinations", boost: 1 },
+    { name: "origins", boost: 1 },
+    { name: "mentions", boost: 1 },
+    { name: "repositories", boost: 1 },
+];
+
+// search analyzers from seachkick, see
+// https://www.rubydoc.info/gems/searchkick/0.1.3/Searchkick%2FSearch:search
+const analyzers = ["searchkick_search", "searchkick_search2"];
+
+// Config for Searchkit SDK; see https://searchkit.co/docs/core/reference/searchkit-sdk
+export const lettersSearchConfig = {
+    host: import.meta.env.VITE_SEARCHKIT_ENDPOINT,
+    connectionOptions: {
+        headers: {
+            authorization: `ApiKey ${import.meta.env.VITE_SEARCHKIT_API_KEY}`,
+        },
+    },
+    index: import.meta.env.VITE_SEARCHKIT_LETTERS_INDEX,
+    hits: {
+        fields: ["id", "recipients", "repositories", "date"],
+    },
+    query: buildQuery({ analyzers, fields }),
+    facets: [
+        new RefinementSelectFacet({
+            field: "language",
+            identifier: "language",
+            label: "Language",
+            multipleSelect: true,
+            order: "value",
+            size: 100, // Show at most 100 facets (there won't be that many!)
+        }),
+    ],
+    sortOptions: [
+        { id: "relevance", label: "Relevance", field: "_score" },
+        { id: "date", label: "Date", field: { date: "asc" } },
+    ],
+    /**
+     * Appends { published: true } filter and sorts by date when there is no query term.
+     *
+     * @param {object} body The original request body object
+     * @returns The modified request body for ElasticSearch
+     */
+    postProcessRequest: (body) => (body?.query
+        ? body
+        : {
+            ...body,
+            query: {
+                bool: {
+                    must: [{ term: { published: true } }],
+                },
+            },
+            sort: [{ date: "asc" }],
+        }),
+};

--- a/src/pages/LettersSearchPage/lettersSearchConfig.js
+++ b/src/pages/LettersSearchPage/lettersSearchConfig.js
@@ -1,5 +1,6 @@
 import { DateRangeFacet, RefinementSelectFacet } from "@ecds/searchkit-sdk";
 import { buildQuery } from "../common/queryBuilder";
+import { MinMaxDateFacet } from "./MinMaxDateFacet";
 
 // kewyord field names to search on
 const fields = [
@@ -32,16 +33,29 @@ export const lettersSearchConfig = {
             field: "date",
             identifier: "date",
             label: "Date",
+            display: "CustomDateFacet",
         }),
-        // TODO: Add this facet (and modify searchkit if necessary) when vaild values are determined
-        // new RefinementSelectFacet({
-        //     field: "volume",
-        //     identifier: "volume",
-        //     label: "Published Volume",
-        //     multipleSelect: true,
-        //     order: "value",
-        //     size: 100,
-        // }),
+        new MinMaxDateFacet({
+            field: "date",
+            identifier: "min_date",
+            label: "Minimum Date",
+            minMax: "min",
+        }),
+        new MinMaxDateFacet({
+            field: "date",
+            identifier: "max_date",
+            label: "Maximum Date",
+            minMax: "max",
+        }),
+        new RefinementSelectFacet({
+            field: "volume",
+            identifier: "volume",
+            label: "Published Volume",
+            multipleSelect: true,
+            order: "value",
+            size: 100,
+            display: "CustomListFacet",
+        }),
         new RefinementSelectFacet({
             field: "language",
             identifier: "language",

--- a/src/pages/common/dateUtil.js
+++ b/src/pages/common/dateUtil.js
@@ -1,0 +1,14 @@
+/**
+ * Format a date string (that is accepted by Date constructor) to the format
+ * "22 March 1929"
+ *
+ * @param {string} date Date as string
+ * @returns {string} Formatted date string
+ */
+export const formatDate = (date) => {
+    const d = new Date(date);
+    const month = new Intl.DateTimeFormat("en-US", {
+        month: "long",
+    }).format(d);
+    return `${d.getDate()} ${month} ${d.getFullYear()}`;
+};

--- a/src/pages/common/index.js
+++ b/src/pages/common/index.js
@@ -1,0 +1,1 @@
+export * from "./queryBuilder";

--- a/src/pages/common/index.js
+++ b/src/pages/common/index.js
@@ -1,1 +1,2 @@
 export * from "./queryBuilder";
+export * from "./dateUtil";

--- a/src/pages/common/index.js
+++ b/src/pages/common/index.js
@@ -1,2 +1,3 @@
-export * from "./queryBuilder";
 export * from "./dateUtil";
+export * from "./queryBuilder";
+export * from "./volumeLabels";

--- a/src/pages/common/queryBuilder.js
+++ b/src/pages/common/queryBuilder.js
@@ -1,0 +1,81 @@
+import { CustomQuery } from "@ecds/searchkit-sdk";
+
+/**
+ * Given a list of Field objects ({ name, boost }), the name of an analyzer for input,
+ * and a search query term, returns a list of ElasticSearch match queries.
+ *
+ * @param {object} kwargs Object of keyword arguments
+ * @param {string} kwargs.analyzer Analyzer name
+ * @param {Array<object>} kwargs.fields Field objects ({ name, boost })
+ * @param {string} kwargs.query Query string
+ * @returns {Array<object>} Array of ElasticSearch "match" query objects
+ */
+export function buildMatchQueries({ analyzer, fields, query }) {
+    // match query adapted from searchkick rails library
+    return fields.map((field) => ({
+        match: {
+            [`${field.name}.analyzed`]: {
+                query,
+                boost: field.boost * 10,
+                operator: "or", // TODO: support "and" operator
+                analyzer,
+            },
+        },
+    }));
+}
+
+/**
+ * Given a list of Field objects ({ name, boost }) and input analyzer names, returns
+ * the custom query for ElasticSearch/Searchkit.
+ *
+ * @param {object} kwargs Object of keyword arguments
+ * @param {Array<string>} kwargs.analyzers List of input analyzer names
+ * @param {Array<object>} kwargs.fields List of Field objects ({ name, boost })
+ * @returns {CustomQuery} Custom query to pass back to Searchkit config
+ */
+function buildQuery({ analyzers, fields }) {
+    return new CustomQuery({
+        /**
+         * Given a query string, returns the bool object for ElasticSearch containing
+         * the query with the published filter applied.
+         *
+         * @param {string} query The query string
+         * @returns {object} The resulting query bool object for ElasticSearch.
+         */
+        queryFn: (query) => {
+            // build array of match queries for each analyzer,
+            // then flatten them into a single array of queries
+            const queries = analyzers
+                .map((analyzer) => buildMatchQueries({
+                    analyzer,
+                    fields,
+                    query,
+                }))
+                .flat();
+            return {
+                bool: {
+                    // should: dis_max adapted from searchkick rails library
+                    should: [
+                        {
+                            dis_max: {
+                                queries,
+                            },
+                        },
+                    ],
+                    // filter to only "published" records
+                    filter: {
+                        term: {
+                            published: {
+                                value: true,
+                            },
+                        },
+                    },
+                    // ensure at least one "should", not only the filter, is applied
+                    minimum_should_match: 1,
+                },
+            };
+        },
+    });
+}
+
+export { buildQuery };

--- a/src/pages/common/search.css
+++ b/src/pages/common/search.css
@@ -1,0 +1,17 @@
+th,
+td {
+    padding: 10px;
+    border: 1px solid #d3dae6;
+}
+th {
+    background: #f5f7fa;
+    text-align: left;
+}
+table {
+    margin-bottom: 2rem;
+    line-height: 1.25;
+    width: 100%;
+}
+ul li:not(:last-of-type) {
+    margin-bottom: 2px;
+}

--- a/src/pages/common/search.css
+++ b/src/pages/common/search.css
@@ -20,3 +20,6 @@ aside {
     width: 25%;
     max-width: 25%;
 }
+div.active-facet-group .euiFlexGroup {
+    flex-flow: row wrap;
+}

--- a/src/pages/common/search.css
+++ b/src/pages/common/search.css
@@ -15,3 +15,8 @@ table {
 ul li:not(:last-of-type) {
     margin-bottom: 2px;
 }
+aside {
+    min-width: 25%;
+    width: 25%;
+    max-width: 25%;
+}

--- a/src/pages/common/volumeLabels.js
+++ b/src/pages/common/volumeLabels.js
@@ -1,0 +1,8 @@
+// mappings for volume labels
+export const volumeLabels = {
+    0: "Unpublished",
+    1: "I",
+    2: "II",
+    3: "III",
+    4: "IV",
+};

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,0 +1,1 @@
+export * from "./LettersSearchPage";

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,1 +1,2 @@
 export * from "./LettersSearchPage";
+export * from "./ErrorPage";


### PR DESCRIPTION
## In this PR

- Adjust page title
- Use new react-router v6 API, connect navigation items to it
- Add error page
- Per #5:
  - Implement keyword search on letters, using similar searchkick-based config to entities
- Per #14:
  - Implement date range filter with special considerations for URL query routing/saved search
- Per #16:
  - Implement language facet (very straightforward)
- Per #17:
  - Implement repository facet
  - Use scrolling container with a max-height and max-width for all facet filters, because this one has a _lot_ of facets

## Questions/notes

- Do we want all the repositories to show up in the facet filter (current behavior), or only the top N results?
- This will likely have some merge conflicts once #11 and #33 are merged. I prefer to merge those first and resolve conflicts on this branch.