### PR TITLE
Entity related letters view (#26, #27)

### DIFF
--- a/src/components/EntityRelatedLetters.css
+++ b/src/components/EntityRelatedLetters.css
@@ -1,0 +1,12 @@
+table.related-letters.search-results {
+    margin-bottom: 0.5rem;
+}
+table.related-letters th {
+    width: 33%;
+}
+.related-letters-header {
+    margin-top: 0.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}

--- a/src/components/EntityRelatedLetters.jsx
+++ b/src/components/EntityRelatedLetters.jsx
@@ -1,0 +1,91 @@
+import moment from "moment";
+import { EuiDatePicker, EuiDatePickerRange, EuiTitle } from "@elastic/eui";
+import { useState } from "react";
+import "./EntityRelatedLetters.css";
+import { Link } from "react-router-dom";
+
+/**
+ *
+ * @param props
+ * @param props.title
+ * @param props.letters
+ */
+export function EntityRelatedLetters({ title, letters }) {
+    const [startDate, setStartDate] = useState(null);
+    const [endDate, setEndDate] = useState(null);
+
+    // min and max date for initial range
+    const dates = letters.map((l) => new Date(l.date).getTime());
+    const minDate = moment(Math.min(...dates));
+    const maxDate = moment(Math.max(...dates));
+
+    return (
+        <section>
+            <div className="related-letters-header">
+                <EuiTitle>
+                    <h2 className="result-heading">{title}</h2>
+                </EuiTitle>
+                <EuiDatePickerRange
+                    startDateControl={(
+                        <EuiDatePicker
+                            selected={startDate}
+                            onChange={setStartDate}
+                            startDate={startDate}
+                            value={startDate || minDate.format("L")}
+                            endDate={endDate}
+                            placeholder="from"
+                            isInvalid={startDate > endDate}
+                            aria-label="Start date"
+                            openToDate={startDate || minDate}
+                        />
+                    )}
+                    endDateControl={(
+                        <EuiDatePicker
+                            selected={endDate}
+                            onChange={setEndDate}
+                            startDate={startDate}
+                            value={endDate || maxDate.format("L")}
+                            endDate={endDate}
+                            isInvalid={startDate > endDate}
+                            placeholder="to"
+                            aria-label="End date"
+                            openToDate={endDate || maxDate}
+                        />
+                    )}
+                />
+            </div>
+            <table className="related-letters search-results">
+                <thead>
+                    <tr>
+                        <th>Recipient</th>
+                        <th>Repository</th>
+                        <th>Date</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {letters
+                        .filter(
+                            (l) => (startDate
+                                ? moment(l.date) >= startDate
+                                : true)
+                                && (endDate ? moment(l.date) <= endDate : true),
+                        )
+                        .map((letter) => (
+                            <tr key={letter.id}>
+                                <td>
+                                    <Link
+                                        className="to-record"
+                                        to={`/letters/${letter.id}`}
+                                    >
+                                        <span>{letter.recipient}</span>
+                                    </Link>
+                                </td>
+                                <td>{letter.repository}</td>
+                                <td>{letter.date}</td>
+                            </tr>
+                        ))}
+                </tbody>
+            </table>
+        </section>
+    );
+}

--- a/src/components/LetterMentions.jsx
+++ b/src/components/LetterMentions.jsx
@@ -3,6 +3,17 @@ import { EuiTitle } from "@elastic/eui";
 import { Link } from "react-router-dom";
 
 /**
+ * Convenience function to parse URI-formatted IDs into UUIDs.
+ *
+ * @param {string} uri URI to parse
+ * @returns {string} Parsed UUID
+ */
+function parseId(uri) {
+    const split = uri.split("/");
+    return split[split.length - 1].replace(".json", "");
+}
+
+/**
  * Letter mentions section component
  *
  * @param {object} props React functional component props object
@@ -27,9 +38,11 @@ export function LetterMentions({ mentions }) {
                             .sort((a, b) => a.label.localeCompare(b.label))
                             .map(
                                 (e) => e.label && (
-                                    <dd key={e.id}>
+                                    <dd key={parseId(e.id)}>
                                         <Link
-                                            to={`/entities/${e.id}`}
+                                            to={`/entities/${parseId(
+                                                e.id,
+                                            )}`}
                                             dangerouslySetInnerHTML={{
                                                 __html: e.label,
                                             }}

--- a/src/pages/EntityPage/EntityPage.jsx
+++ b/src/pages/EntityPage/EntityPage.jsx
@@ -8,6 +8,7 @@ import {
 } from "@elastic/eui";
 import React from "react";
 import { Navigate, useLoaderData } from "react-router-dom";
+import { EntityRelatedLetters } from "../../components/EntityRelatedLetters";
 import { getFromApi } from "../common";
 import "../common/result.css";
 import "./EntityPage.css";
@@ -22,6 +23,14 @@ import "./EntityPage.css";
 export function entityLoader({ params }) {
     return getFromApi(`/entities/${params.entityId}`);
 }
+
+const relatedLettersMapping = {
+    recived: "Letters Received",
+    sent: "Letters Sent",
+    sent_to: "Destination Of",
+    sent_from: "Origin Of",
+    mentioned_in: "Mentioned In",
+};
 
 /**
  * Page for individual entity records.
@@ -68,6 +77,16 @@ export function EntityPage() {
                                 className="entity-details"
                             />
                         </section>
+                        {entity.letters
+                            && Object.entries(entity.letters).map(
+                                ([key, value]) => (
+                                    <EntityRelatedLetters
+                                        key={key}
+                                        title={relatedLettersMapping[key]}
+                                        letters={value}
+                                    />
+                                ),
+                            )}
                     </EuiPageContent>
                 </EuiPageBody>
             </EuiPage>


### PR DESCRIPTION
## In this PR

- Fix error with unparsed URI-formatted UUIDs
- Per #26 and #27:
  - View related letters on entity detail pages
  - Allow filtering by date
  - Link letters to their detail pages