### PR TITLE
Boolean AND/OR operators (#7)

### DIFF
--- a/src/common/index.js
+++ b/src/common/index.js
@@ -2,4 +2,5 @@ export * from "./dateUtil";
 export * from "./entityTypes";
 export * from "./fetch";
 export * from "./queryBuilder";
+export * from "./useCustomSearchkitSDK";
 export * from "./volumeLabels";

--- a/src/common/queryBuilder.js
+++ b/src/common/queryBuilder.js
@@ -8,16 +8,19 @@ import { CustomQuery } from "@ecds/searchkit-sdk";
  * @param {string} kwargs.analyzer Analyzer name
  * @param {Array<object>} kwargs.fields Field objects ({ name, boost })
  * @param {string} kwargs.query Query string
+ * @param {string} kwargs.operator Search operator
  * @returns {Array<object>} Array of ElasticSearch "match" query objects
  */
-export function buildMatchQueries({ analyzer, fields, query }) {
+export function buildMatchQueries({
+    analyzer, fields, operator, query,
+}) {
     // match query adapted from searchkick rails library
     return fields.map((field) => ({
         match: {
             [`${field.name}.analyzed`]: {
                 query,
                 boost: field.boost * 10,
-                operator: "or", // TODO: support "and" operator
+                operator,
                 analyzer,
             },
         },
@@ -31,9 +34,10 @@ export function buildMatchQueries({ analyzer, fields, query }) {
  * @param {object} kwargs Object of keyword arguments
  * @param {Array<string>} kwargs.analyzers List of input analyzer names
  * @param {Array<object>} kwargs.fields List of Field objects ({ name, boost })
+ * @param {string} kwargs.operator Search operator
  * @returns {CustomQuery} Custom query to pass back to Searchkit config
  */
-function buildQuery({ analyzers, fields }) {
+function buildQuery({ analyzers, fields, operator }) {
     return new CustomQuery({
         /**
          * Given a query string, returns the bool object for ElasticSearch containing
@@ -49,6 +53,7 @@ function buildQuery({ analyzers, fields }) {
                 .map((analyzer) => buildMatchQueries({
                     analyzer,
                     fields,
+                    operator: operator || "or",
                     query,
                 }))
                 .flat();

--- a/src/common/result.css
+++ b/src/common/result.css
@@ -6,6 +6,9 @@
     position: absolute;
     left: 24px;
 }
+.result-name .euiPageHeaderSection {
+    max-width: 80%;
+}
 .result-meta-heading,
 .result-heading {
     margin-bottom: 0.5rem;

--- a/src/common/search.css
+++ b/src/common/search.css
@@ -41,7 +41,12 @@ aside a,
 section header button:not(:disabled) span {
     color: var(--primary-dark);
 }
-
+aside .operator-icon {
+    margin-left: 0.5rem;
+}
+.operator-tooltip {
+    text-align: center;
+}
 /* ensure search button flush with right of search form */
 aside .search-button-container {
     text-align: right;

--- a/src/common/search.css
+++ b/src/common/search.css
@@ -19,7 +19,6 @@ table.search-results tr {
 }
 
 /* search filters panel style */
-
 aside {
     align-self: center;
     width: 100%;
@@ -41,6 +40,11 @@ aside ul li:not(:last-of-type) {
 aside a,
 section header button:not(:disabled) span {
     color: var(--primary-dark);
+}
+
+/* ensure search button flush with right of search form */
+aside .search-button-container {
+    text-align: right;
 }
 
 /* prevent multiple applied facets from causing horizontal scroll */

--- a/src/common/useCustomSearchkitSDK.js
+++ b/src/common/useCustomSearchkitSDK.js
@@ -1,0 +1,56 @@
+import createInstance from "@ecds/searchkit-sdk";
+import { useEffect, useState } from "react";
+import { buildQuery } from "./queryBuilder";
+
+/**
+ * Hook that performs a search using chosen configuration.
+ * Adapted from @searchkit/sdk, but customized to allow changing operator.
+ *
+ * @param {object} kwargs Object of options for the hook
+ * @param {Array<string>} kwargs.analyzers List of input analyzer names
+ * @param {object} kwargs.config Initial search config
+ * @param {Array<object>} kwargs.fields List of Field objects ({ name, boost })
+ * @param {string} kwargs.operator Search operator
+ * @param {object} kwargs.variables Search state variables
+ * @returns {object} Response in the form { results: SearchkitResponse; loading: boolean }
+ */
+export const useCustomSearchkitSDK = ({
+    config,
+    analyzers,
+    fields,
+    variables,
+    operator,
+}) => {
+    const [results, setResponse] = useState(null);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        // eslint-disable-next-line jsdoc/require-jsdoc
+        async function fetchData(vars, oper) {
+            setLoading(true);
+            const request = createInstance({
+                ...config,
+                query: buildQuery({ analyzers, fields, operator: oper }),
+            })
+                .query(vars.query)
+                .setFilters(vars.filters)
+                .setSortBy(vars.sortBy);
+
+            const response = await request.execute({
+                facets: true,
+                hits: {
+                    size: vars.page.size,
+                    from: vars.page.from,
+                },
+            });
+            setLoading(false);
+            setResponse(response);
+        }
+
+        if (variables) {
+            fetchData(variables, operator);
+        }
+    }, [variables, operator]);
+
+    return { results, loading };
+};

--- a/src/components/SearchControls.jsx
+++ b/src/components/SearchControls.jsx
@@ -5,6 +5,7 @@ import {
     EuiFieldSearch,
     EuiFlexGroup,
     EuiFlexItem,
+    EuiIconTip,
     EuiSpacer,
 } from "@elastic/eui";
 
@@ -60,6 +61,16 @@ export function SearchControls({
                                     label: "AND",
                                 },
                             ]}
+                        />
+                        <EuiIconTip
+                            className="operator-tooltip"
+                            position="bottom"
+                            type="questionInCircle"
+                            color="subdued"
+                            content="Choose OR to match any entered keyword, choose AND to match all keywords."
+                            iconProps={{
+                                className: "operator-icon",
+                            }}
                         />
                     </div>
                 </EuiFlexItem>

--- a/src/components/SearchControls.jsx
+++ b/src/components/SearchControls.jsx
@@ -1,0 +1,84 @@
+import React from "react";
+import {
+    EuiButton,
+    EuiButtonGroup,
+    EuiFieldSearch,
+    EuiFlexGroup,
+    EuiFlexItem,
+    EuiSpacer,
+} from "@elastic/eui";
+
+/**
+ * Component for the search bar, the and/or operator picker, and the search submit button.
+ *
+ * @param {object} props React functional component props object
+ * @param {boolean} props.loading Boolean for loading indicators
+ * @param {Function} props.onSearch Event handler function for submitting search
+ * @param {string} props.operator Currently selected operator
+ * @param {Function} props.setOperator Event handler function for changing the operator
+ * @param {Function} props.setQuery Event handler function for typing in the search bar
+ * @param {string} props.query Current query
+ * @returns {React.Component} React functional component for search controls
+ */
+export function SearchControls({
+    loading,
+    onSearch,
+    operator,
+    setOperator,
+    setQuery,
+    query,
+}) {
+    return (
+        <>
+            <EuiFieldSearch
+                placeholder="Search"
+                value={query}
+                onChange={(e) => {
+                    setQuery(e.target.value);
+                }}
+                isLoading={loading}
+                onSearch={onSearch}
+                isClearable
+                aria-label="Search"
+            />
+            <EuiSpacer size="m" />
+            <EuiFlexGroup justifyContent="spaceBetween">
+                <EuiFlexItem>
+                    <div>
+                        <EuiButtonGroup
+                            isDisabled={loading}
+                            legend="Choose a search operator"
+                            idSelected={operator}
+                            onChange={(optionId) => setOperator(optionId)}
+                            options={[
+                                {
+                                    id: "or",
+                                    label: "OR",
+                                },
+                                {
+                                    id: "and",
+                                    label: "AND",
+                                },
+                            ]}
+                        />
+                    </div>
+                </EuiFlexItem>
+                <EuiFlexItem>
+                    <div className="search-button-container">
+                        <EuiButton
+                            iconType="search"
+                            iconSide="right"
+                            isLoading={loading}
+                            size="s"
+                            fill
+                            onClick={() => onSearch(query)}
+                            type="submit"
+                        >
+                            Search
+                        </EuiButton>
+                    </div>
+                </EuiFlexItem>
+            </EuiFlexGroup>
+        </>
+    );
+}

--- a/src/pages/EntitiesSearchPage/EntitiesSearchPage.jsx
+++ b/src/pages/EntitiesSearchPage/EntitiesSearchPage.jsx
@@ -31,6 +31,7 @@ import { icon as EuiIconArrowLeft } from "@elastic/eui/es/components/icon/assets
 import { icon as EuiIconArrowRight } from "@elastic/eui/es/components/icon/assets/arrow_right";
 import { icon as EuiIconCross } from "@elastic/eui/es/components/icon/assets/cross";
 import { icon as EuiIconSearch } from "@elastic/eui/es/components/icon/assets/search";
+import { icon as EuiIconQuestion } from "@elastic/eui/es/components/icon/assets/question_in_circle";
 import {
     analyzers,
     entitiesSearchConfig,
@@ -49,6 +50,7 @@ appendIconComponentCache({
     arrowRight: EuiIconArrowRight,
     cross: EuiIconCross,
     search: EuiIconSearch,
+    questionInCircle: EuiIconQuestion,
 });
 
 /**

--- a/src/pages/EntitiesSearchPage/EntitiesSearchPage.jsx
+++ b/src/pages/EntitiesSearchPage/EntitiesSearchPage.jsx
@@ -1,12 +1,12 @@
-// eslint-disable-next-line import/no-unresolved
-import { useSearchkitSDK } from "@ecds/searchkit-sdk/src/react-hooks";
+import { useState } from "react";
 import {
     SearchkitClient,
+    useSearchkit,
+    useSearchkitQueryValue,
     useSearchkitVariables,
     withSearchkit,
 } from "@searchkit/client";
 import {
-    SearchBar,
     ResetSearchButton,
     SelectedFilters,
     Pagination,
@@ -31,11 +31,16 @@ import { icon as EuiIconArrowLeft } from "@elastic/eui/es/components/icon/assets
 import { icon as EuiIconArrowRight } from "@elastic/eui/es/components/icon/assets/arrow_right";
 import { icon as EuiIconCross } from "@elastic/eui/es/components/icon/assets/cross";
 import { icon as EuiIconSearch } from "@elastic/eui/es/components/icon/assets/search";
-
-import { entitiesSearchConfig } from "./entitiesSearchConfig";
+import {
+    analyzers,
+    entitiesSearchConfig,
+    fields,
+} from "./entitiesSearchConfig";
 import EntitiesResults from "../../components/EntitiesResults";
 import ListFacet from "../../components/ListFacet";
 import withSearchRouting from "../../components/withSearchRouting";
+import { SearchControls } from "../../components/SearchControls";
+import { useCustomSearchkitSDK } from "../../common";
 
 // icon component cache required for dynamically imported EUI icons in Vite;
 // see https://github.com/elastic/eui/issues/5463
@@ -52,17 +57,34 @@ appendIconComponentCache({
  * @returns React entities search page component
  */
 function EntitiesSearch() {
+    const [query, setQuery] = useSearchkitQueryValue();
+    const [operator, setOperator] = useState("or");
+    const api = useSearchkit();
     const variables = useSearchkitVariables();
-    const { results, loading } = useSearchkitSDK(
-        entitiesSearchConfig,
+    const { results, loading } = useCustomSearchkitSDK({
+        analyzers,
+        config: entitiesSearchConfig,
+        fields,
+        operator,
         variables,
-    );
+    });
     return (
         <main>
             <EuiPage paddingSize="l">
                 <aside>
                     <EuiPageSideBar>
-                        <SearchBar loading={loading} />
+                        <SearchControls
+                            loading={loading}
+                            onSearch={(value) => {
+                                setQuery(value);
+                                api.setQuery(value);
+                                api.search();
+                            }}
+                            operator={operator}
+                            setOperator={setOperator}
+                            setQuery={setQuery}
+                            query={query}
+                        />
                         <EuiHorizontalRule margin="m" />
                         {results?.facets.map((facet) => (
                             <ListFacet

--- a/src/pages/EntitiesSearchPage/entitiesSearchConfig.js
+++ b/src/pages/EntitiesSearchPage/entitiesSearchConfig.js
@@ -2,7 +2,7 @@ import { RefinementSelectFacet } from "@ecds/searchkit-sdk";
 import { buildQuery } from "../../common";
 
 // kewyord field names to search on
-const fields = [
+export const fields = [
     { name: "clean_label", boost: 10 },
     { name: "clean_description", boost: 5 },
     { name: "alternate_names", boost: 9 },
@@ -11,7 +11,7 @@ const fields = [
 
 // search analyzers from seachkick, see
 // https://www.rubydoc.info/gems/searchkick/0.1.3/Searchkick%2FSearch:search
-const analyzers = ["searchkick_search", "searchkick_search2"];
+export const analyzers = ["searchkick_search", "searchkick_search2"];
 
 // Config for Searchkit SDK; see https://searchkit.co/docs/core/reference/searchkit-sdk
 export const entitiesSearchConfig = {

--- a/src/pages/LettersSearchPage/lettersSearchConfig.js
+++ b/src/pages/LettersSearchPage/lettersSearchConfig.js
@@ -4,7 +4,7 @@ import { CustomDateRangeFacet } from "./CustomDateRangeFacet";
 import { MinMaxDateFacet } from "./MinMaxDateFacet";
 
 // kewyord field names to search on
-const fields = [
+export const fields = [
     { name: "recipients", boost: 2 },
     { name: "destinations", boost: 1 },
     { name: "origins", boost: 1 },
@@ -14,7 +14,7 @@ const fields = [
 
 // search analyzers from seachkick, see
 // https://www.rubydoc.info/gems/searchkick/0.1.3/Searchkick%2FSearch:search
-const analyzers = ["searchkick_search", "searchkick_search2"];
+export const analyzers = ["searchkick_search", "searchkick_search2"];
 
 // Config for Searchkit SDK; see https://searchkit.co/docs/core/reference/searchkit-sdk
 export const lettersSearchConfig = {


### PR DESCRIPTION
## In this PR

- Cleanup style for long titles in result pages
- Per #7:
  - Allow switching between AND/OR operators on the search page, adapting `useSearchkitSDK` to allow configuring this on the fly
  - Improve search query frontend with new `SearchControls` reusable component including boolean options, and new "search" submit button

## Questions

- Do we need to handle "NOT"? I didn't see it in the original API nor was it in our original statement of work, but it is in the user story. If we need it, we should discuss in next Monday's meeting.