### PR TITLE
Implement sortable columns in letters search (#18)

### DIFF
--- a/src/components/LettersResults.jsx
+++ b/src/components/LettersResults.jsx
@@ -1,6 +1,7 @@
 import { Link } from "react-router-dom";
 import { formatDate } from "../common";
 import "./LettersResults.css";
+import { SortableHeader } from "./SortableHeader";
 
 /**
  * List of results for the Letters search view.
@@ -8,17 +9,28 @@ import "./LettersResults.css";
  * @param {object} props Props for React functional component
  * @param {object} props.data Data returned by ElasticSearch
  * @param {number} props.offset Offset of results for current page
+ * @param {Function} props.onSort Sort handler
+ * @param {object} props.sortState Current sort state
  * @returns Populated results list React component
  */
-function LettersResults({ data, offset }) {
+function LettersResults({
+    data, offset, onSort, sortState,
+}) {
+    const sortableColumns = ["recipient", "repository", "date"];
     return (
         <table id="letters-results" className="search-results">
             <thead>
                 <tr>
                     <th aria-label="index">#</th>
-                    <th>Recipient</th>
-                    <th>Repository</th>
-                    <th>Date</th>
+                    {sortableColumns.map((column) => (
+                        <th key={column}>
+                            <SortableHeader
+                                name={column}
+                                onSort={onSort}
+                                sortState={sortState}
+                            />
+                        </th>
+                    ))}
                 </tr>
             </thead>
             <tbody>

--- a/src/components/SortableHeader.css
+++ b/src/components/SortableHeader.css
@@ -1,0 +1,8 @@
+table th div.sortable-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+table th div.sortable-header span {
+    text-transform: capitalize;
+}

--- a/src/components/SortableHeader.jsx
+++ b/src/components/SortableHeader.jsx
@@ -1,0 +1,46 @@
+import { EuiButtonIcon } from "@elastic/eui";
+import React from "react";
+import "./SortableHeader.css";
+
+/**
+ * Gets the icon for the sort state (up or down if sorted, "sortable" if not)
+ *
+ * @param {object} sortState Sort state object which includes the field sorted and direction of sort
+ * @param {string} field The field to which the icon will be applied
+ * @returns {string} The icon name for the field's sort state
+ */
+const getSortIcon = (sortState, field) => {
+    if (sortState?.field === field) {
+        return sortState.direction === 1 ? "sortUp" : "sortDown";
+    }
+    return "sortable";
+};
+
+/**
+ * React component for sortable column headers in a table.
+ *
+ * @param {object} props React functional components props object
+ * @param {Function} props.onSort Event handler for clicking the sort button
+ * @param {object} props.sortState Current sort state object
+ * @param {string} props.name The field name of this column
+ * @returns {React.Component} React functional component for the sortable header
+ */
+export function SortableHeader({ name, onSort, sortState }) {
+    return (
+        <div className="sortable-header">
+            <span>{name}</span>
+            <EuiButtonIcon
+                size="xs"
+                color={
+                    getSortIcon(sortState, name) === "sortable"
+                        ? "text"
+                        : "primary"
+                }
+                display="empty"
+                iconType={getSortIcon(sortState, name)}
+                onClick={onSort(name)}
+                aria-label={`Sort by ${name}`}
+            />
+        </div>
+    );
+}

--- a/src/pages/EntitiesSearchPage/EntitiesSearchPage.jsx
+++ b/src/pages/EntitiesSearchPage/EntitiesSearchPage.jsx
@@ -123,15 +123,21 @@ function EntitiesSearch() {
                                 </EuiTitle>
                             </EuiPageContentHeaderSection>
                         </EuiPageContentHeader>
-                        <EuiPageContentBody>
-                            <EntitiesResults
-                                data={results}
-                                offset={variables?.page?.from}
-                            />
-                            <EuiFlexGroup justifyContent="spaceAround">
-                                <Pagination data={results} />
-                            </EuiFlexGroup>
-                        </EuiPageContentBody>
+                        {results?.summary?.total > 0 ? (
+                            <EuiPageContentBody>
+                                <EntitiesResults
+                                    data={results}
+                                    offset={variables?.page?.from}
+                                />
+                                <EuiFlexGroup justifyContent="spaceAround">
+                                    <Pagination data={results} />
+                                </EuiFlexGroup>
+                            </EuiPageContentBody>
+                        ) : (
+                            <EuiPageContentBody>
+                                Your search did not return any results.
+                            </EuiPageContentBody>
+                        )}
                     </EuiPageContent>
                 </EuiPageBody>
             </EuiPage>

--- a/src/pages/LettersSearchPage/lettersSearchConfig.js
+++ b/src/pages/LettersSearchPage/lettersSearchConfig.js
@@ -82,18 +82,36 @@ export const lettersSearchConfig = {
     ],
     sortOptions: [
         { id: "relevance", label: "Relevance", field: "_score" },
-        { id: "date", label: "Date", field: { date: "asc" } },
+        {
+            id: "date_asc",
+            label: "Date (Ascending)",
+            field: { date: "asc" },
+            defaultOption: true,
+        },
+        {
+            id: "date_desc",
+            label: "Date (Descending)",
+            field: { date: "desc" },
+        },
+        {
+            id: "recipient_asc",
+            label: "Recipient (Ascending)",
+            field: { recipients: "asc" },
+        },
+        {
+            id: "recipient_desc",
+            label: "Recipient (Descending)",
+            field: { recipients: "desc" },
+        },
+        {
+            id: "repository_asc",
+            label: "Recipient (Ascending)",
+            field: { repositories: "asc" },
+        },
+        {
+            id: "repository_desc",
+            label: "Recipient (Descending)",
+            field: { repositories: "desc" },
+        },
     ],
-    /**
-     * Sorts by date when there is no query term.
-     *
-     * @param {object} body The original request body object
-     * @returns The modified request body for ElasticSearch
-     */
-    postProcessRequest: (body) => (body?.query
-        ? body
-        : {
-            ...body,
-            sort: [{ date: "asc" }],
-        }),
 };


### PR DESCRIPTION
## In this PR

- Add "no results" text for when you enter a query that produces no results (+ avoid displaying the table/pagination in that case)
- Per #18:
  - Allow sorting by each column in the letters search view