### PR TITLE
Add scope dropdown to letters search (#12, #13)

### DIFF
--- a/src/common/search.css
+++ b/src/common/search.css
@@ -1,3 +1,12 @@
+main.search-page > div.euiPage {
+    flex-flow: row wrap;
+}
+@media (min-width: 900px) {
+    main.search-page > div.euiPage {
+        flex-flow: row nowrap;
+    }
+}
+
 /* search results table style */
 table.search-results {
     margin-bottom: 2rem;
@@ -19,19 +28,18 @@ table.search-results tr {
 }
 
 /* search filters panel style */
-aside {
+main.search-page aside {
     align-self: center;
     width: 100%;
     max-width: 400px;
     margin: 0 auto;
 }
-@media (min-width: 768px) {
-    aside {
+@media (min-width: 900px) {
+    main.search-page aside {
         align-self: flex-start;
         width: 25%;
-        min-width: 25%;
+        min-width: max(25%, 300px);
         max-width: 25%;
-        margin: auto;
     }
 }
 aside ul li:not(:last-of-type) {
@@ -59,7 +67,8 @@ div.active-facet-group .euiFlexGroup {
 div.active-facet-group button {
     background-color: var(--primary-transparent);
 }
-div.active-facet-group button.euiButton--primary:not([class*='isDisabled']):hover {
+div.active-facet-group
+    button.euiButton--primary:not([class*="isDisabled"]):hover {
     background-color: var(--primary-dark-transparent);
 }
 div.active-facet-group button a,

--- a/src/common/useCustomSearchkitSDK.js
+++ b/src/common/useCustomSearchkitSDK.js
@@ -12,6 +12,7 @@ import { buildQuery } from "./queryBuilder";
  * @param {Array<object>} kwargs.fields List of Field objects ({ name, boost })
  * @param {string} kwargs.operator Search operator
  * @param {object} kwargs.variables Search state variables
+ * @param {string?} kwargs.scope An optional argument to limit the search to a single field
  * @returns {object} Response in the form { results: SearchkitResponse; loading: boolean }
  */
 export const useCustomSearchkitSDK = ({
@@ -20,6 +21,7 @@ export const useCustomSearchkitSDK = ({
     fields,
     variables,
     operator,
+    scope,
 }) => {
     const [results, setResponse] = useState(null);
     const [loading, setLoading] = useState(true);
@@ -30,7 +32,14 @@ export const useCustomSearchkitSDK = ({
             setLoading(true);
             const request = createInstance({
                 ...config,
-                query: buildQuery({ analyzers, fields, operator: oper }),
+                query: buildQuery({
+                    analyzers,
+                    fields:
+                        !scope || scope === "keyword"
+                            ? fields
+                            : [{ name: scope, boost: 10 }],
+                    operator: oper,
+                }),
             })
                 .query(vars.query)
                 .setFilters(vars.filters)

--- a/src/components/SearchControls.css
+++ b/src/components/SearchControls.css
@@ -1,0 +1,32 @@
+/* dropdown style */
+.euiFormControlLayout--group .euiFormControlLayout:first-child {
+    max-width: 122.5px;
+}
+.euiFormControlLayout--group
+    .euiFormControlLayout:first-child
+    .euiFormControlLayout__childrenWrapper {
+    max-height: 99%;
+}
+.euiFormControlLayout--group
+    .euiFormControlLayout__childrenWrapper:last-child
+    select.type-select {
+    border: none;
+    box-shadow: none;
+    outline: none;
+    border-top-left-radius: 6px;
+    border-bottom-left-radius: 8px;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+    border-right: 1px solid rgba(52, 55, 65, 0.2);
+}
+
+/* ensure no wrapping on boolean + search button container on mobile */
+div.controls-group {
+    flex-wrap: nowrap;
+}
+
+@media (min-width: 900px) {
+    div.controls-group {
+        flex-wrap: wrap;
+    }
+}

--- a/src/components/SearchControls.jsx
+++ b/src/components/SearchControls.jsx
@@ -6,8 +6,10 @@ import {
     EuiFlexGroup,
     EuiFlexItem,
     EuiIconTip,
+    EuiSelect,
     EuiSpacer,
 } from "@elastic/eui";
+import "./SearchControls.css";
 
 /**
  * Component for the search bar, the and/or operator picker, and the search submit button.
@@ -19,14 +21,20 @@ import {
  * @param {Function} props.setOperator Event handler function for changing the operator
  * @param {Function} props.setQuery Event handler function for typing in the search bar
  * @param {string} props.query Current query
+ * @param {string} props.scope Current search scope state (keyword, recipient, repository)
+ * @param {Array<object>} props.scopeOptions List of label/value pairs for search scope options
+ * @param {Function} props.setScope Function to set the search scope state
  * @returns {React.Component} React functional component for search controls
  */
 export function SearchControls({
     loading,
     onSearch,
     operator,
+    scope,
+    scopeOptions,
     setOperator,
     setQuery,
+    setScope,
     query,
 }) {
     return (
@@ -41,9 +49,22 @@ export function SearchControls({
                 onSearch={onSearch}
                 isClearable
                 aria-label="Search"
+                prepend={
+                    scopeOptions && (
+                        <EuiSelect
+                            className="type-select"
+                            options={scopeOptions}
+                            onChange={(e) => setScope(e.target.value)}
+                            value={scope}
+                        />
+                    )
+                }
             />
             <EuiSpacer size="m" />
-            <EuiFlexGroup justifyContent="spaceBetween">
+            <EuiFlexGroup
+                justifyContent="spaceBetween"
+                className="controls-group"
+            >
                 <EuiFlexItem>
                     <div>
                         <EuiButtonGroup

--- a/src/pages/EntitiesSearchPage/EntitiesSearchPage.jsx
+++ b/src/pages/EntitiesSearchPage/EntitiesSearchPage.jsx
@@ -71,7 +71,7 @@ function EntitiesSearch() {
         variables,
     });
     return (
-        <main>
+        <main className="search-page">
             <EuiPage paddingSize="l">
                 <aside>
                     <EuiPageSideBar>

--- a/src/pages/HomePage/HomePage.css
+++ b/src/pages/HomePage/HomePage.css
@@ -31,7 +31,7 @@ main#home .home-container {
     background-color: #fafbfd;
 }
 
-@media (min-width: 768px) {
+@media (min-width: 900px) {
     main#home .description {
         display: grid;
         grid-template-columns: auto auto;

--- a/src/pages/LettersSearchPage/LettersSearchPage.jsx
+++ b/src/pages/LettersSearchPage/LettersSearchPage.jsx
@@ -23,6 +23,7 @@ import {
     EuiSpacer,
 } from "@elastic/eui";
 import { appendIconComponentCache } from "@elastic/eui/es/components/icon/icon";
+import { icon as EuiIconArrowDown } from "@elastic/eui/es/components/icon/assets/arrow_down";
 import { icon as EuiIconArrowLeft } from "@elastic/eui/es/components/icon/assets/arrow_left";
 import { icon as EuiIconArrowRight } from "@elastic/eui/es/components/icon/assets/arrow_right";
 import { icon as EuiIconCross } from "@elastic/eui/es/components/icon/assets/cross";
@@ -31,7 +32,9 @@ import { icon as EuiIconSearch } from "@elastic/eui/es/components/icon/assets/se
 import { icon as EuiIconSortable } from "@elastic/eui/es/components/icon/assets/sortable";
 import { icon as EuiIconSortUp } from "@elastic/eui/es/components/icon/assets/sort_up";
 import { icon as EuiIconSortDown } from "@elastic/eui/es/components/icon/assets/sort_down";
-import { lettersSearchConfig, analyzers, fields } from "./lettersSearchConfig";
+import {
+    lettersSearchConfig, analyzers, fields, scopeOptions,
+} from "./lettersSearchConfig";
 import LettersResults from "../../components/LettersResults";
 import ListFacet from "../../components/ListFacet";
 import ValueFilter from "../../components/ValueFilter";
@@ -46,6 +49,7 @@ import { useCustomSearchkitSDK } from "../../common";
 appendIconComponentCache({
     arrowLeft: EuiIconArrowLeft,
     arrowRight: EuiIconArrowRight,
+    arrowDown: EuiIconArrowDown,
     calendar: EuiIconCalendar,
     cross: EuiIconCross,
     search: EuiIconSearch,
@@ -66,6 +70,7 @@ function LettersSearch() {
         field: "date",
         direction: 1,
     });
+    const [scope, setScope] = useState("keyword");
     /**
      * Curried event listener funciton to set the sort state to a given field.
      *
@@ -97,9 +102,10 @@ function LettersSearch() {
         fields,
         operator,
         variables,
+        scope,
     });
     return (
-        <main>
+        <main className="search-page">
             <EuiPage paddingSize="l">
                 <aside>
                     <EuiPageSideBar>
@@ -114,6 +120,9 @@ function LettersSearch() {
                             setOperator={setOperator}
                             setQuery={setQuery}
                             query={query}
+                            scopeOptions={scopeOptions}
+                            scope={scope}
+                            setScope={setScope}
                         />
                         <EuiHorizontalRule margin="m" />
                         <DateRangeFacet data={results} loading={loading} />

--- a/src/pages/LettersSearchPage/lettersSearchConfig.js
+++ b/src/pages/LettersSearchPage/lettersSearchConfig.js
@@ -12,6 +12,14 @@ export const fields = [
     { name: "repositories", boost: 1 },
 ];
 
+// search scopes (keyword search, recipient name search, repository search)
+// values besides "keyword" must match names of fields in the index
+export const scopeOptions = [
+    { value: "keyword", text: "Keyword" },
+    { value: "recipients", text: "Recipient" },
+    { value: "repositories", text: "Repository" },
+];
+
 // search analyzers from seachkick, see
 // https://www.rubydoc.info/gems/searchkick/0.1.3/Searchkick%2FSearch:search
 export const analyzers = ["searchkick_search", "searchkick_search2"];


### PR DESCRIPTION
## In this PR

- Make some pages' UI more responsive
- Per #12 and #13:
  - Add dropdown with "Keyword," "Recipient," and "Repository" options to letters search dropdown