### PR TITLE
Date filter revisions (#14)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "name": "beckett-search-ui",
             "version": "0.0.0",
             "dependencies": {
-                "@ecds/searchkit-elastic-ui": "^3.0.1-alpha.2",
+                "@ecds/searchkit-elastic-ui": "^3.0.1-alpha.5",
                 "@ecds/searchkit-sdk": "^3.0.1-alpha.1",
                 "@elastic/eui": "^42.1.0",
                 "@searchkit/client": "^3.0.0",
@@ -489,9 +489,9 @@
             }
         },
         "node_modules/@ecds/searchkit-elastic-ui": {
-            "version": "3.0.1-alpha.2",
-            "resolved": "https://registry.npmjs.org/@ecds/searchkit-elastic-ui/-/searchkit-elastic-ui-3.0.1-alpha.2.tgz",
-            "integrity": "sha512-kncDthbSkY/iuFujUu8AIcwV2Rf6ZEm/0PcwcGTCY1coBOgj9zr9HK674WpT3MnUzREFupWDC+4xx6iutYvDGw==",
+            "version": "3.0.1-alpha.5",
+            "resolved": "https://registry.npmjs.org/@ecds/searchkit-elastic-ui/-/searchkit-elastic-ui-3.0.1-alpha.5.tgz",
+            "integrity": "sha512-aKRYEiN1qtmtn+YQxu5MXPlSlKcKB2U1D4q3Kt/FcNd8Mah2YAY3baMFXlMG+yodD4rzdNXQfRzA4u4plKUSHQ==",
             "dependencies": {
                 "use-debounce": "^5.0.3"
             },
@@ -6477,9 +6477,9 @@
             }
         },
         "@ecds/searchkit-elastic-ui": {
-            "version": "3.0.1-alpha.2",
-            "resolved": "https://registry.npmjs.org/@ecds/searchkit-elastic-ui/-/searchkit-elastic-ui-3.0.1-alpha.2.tgz",
-            "integrity": "sha512-kncDthbSkY/iuFujUu8AIcwV2Rf6ZEm/0PcwcGTCY1coBOgj9zr9HK674WpT3MnUzREFupWDC+4xx6iutYvDGw==",
+            "version": "3.0.1-alpha.5",
+            "resolved": "https://registry.npmjs.org/@ecds/searchkit-elastic-ui/-/searchkit-elastic-ui-3.0.1-alpha.5.tgz",
+            "integrity": "sha512-aKRYEiN1qtmtn+YQxu5MXPlSlKcKB2U1D4q3Kt/FcNd8Mah2YAY3baMFXlMG+yodD4rzdNXQfRzA4u4plKUSHQ==",
             "requires": {
                 "use-debounce": "^5.0.3"
             }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "preview": "vite preview"
     },
     "dependencies": {
-        "@ecds/searchkit-elastic-ui": "^3.0.1-alpha.2",
+        "@ecds/searchkit-elastic-ui": "^3.0.1-alpha.5",
         "@ecds/searchkit-sdk": "^3.0.1-alpha.1",
         "@elastic/eui": "^42.1.0",
         "@searchkit/client": "^3.0.0",

--- a/src/common/dateUtil.js
+++ b/src/common/dateUtil.js
@@ -27,6 +27,8 @@ export const formatDate = (date) => {
  */
 export const datesValid = ({
     startDate, endDate, min, max,
-}) => (startDate && endDate ? startDate < endDate : true)
+}) => (startDate && endDate ? startDate <= endDate : true)
     && (startDate && max ? startDate <= max : true)
+    && (startDate && min ? startDate >= min : true)
+    && (endDate && max ? endDate <= max : true)
     && (endDate && min ? endDate >= min : true);

--- a/src/common/useCustomSearchkitSDK.js
+++ b/src/common/useCustomSearchkitSDK.js
@@ -1,5 +1,6 @@
 import createInstance from "@ecds/searchkit-sdk";
 import { useEffect, useState } from "react";
+import moment from "moment";
 import { buildQuery } from "./queryBuilder";
 
 /**
@@ -23,7 +24,38 @@ export const useCustomSearchkitSDK = ({
 }) => {
     const [results, setResponse] = useState(null);
     const [loading, setLoading] = useState(true);
+    const [dateRange, setDateRange] = useState(null);
+    const [dateRangeLoading, setDateRangeLoading] = useState(true);
 
+    if (config?.name === "letters") {
+        // initial request to get global date range with no filters/query
+        useEffect(() => {
+            // eslint-disable-next-line jsdoc/require-jsdoc
+            async function fetchData() {
+                setDateRangeLoading(true);
+                const request = createInstance({
+                    ...config,
+                    query: buildQuery({ analyzers, fields }),
+                });
+                const response = await request.execute({
+                    facets: true,
+                    hits: { size: 0 },
+                });
+                // get min and max date facet values
+                const min = response?.facets?.find((f) => f.identifier === "min_date")
+                    ?.value || null;
+                const minDate = min ? moment(min) : null;
+                const max = response?.facets?.find((f) => f.identifier === "max_date")
+                    ?.value || null;
+                const maxDate = max ? moment(max) : null;
+                setDateRange({ minDate, maxDate });
+                setDateRangeLoading(false);
+            }
+            fetchData();
+        }, []); // (perform once, on page render)
+    }
+
+    // other requests with filters applied, if/whenever they change
     useEffect(() => {
         // eslint-disable-next-line jsdoc/require-jsdoc
         async function fetchData(vars, oper) {
@@ -52,5 +84,10 @@ export const useCustomSearchkitSDK = ({
         }
     }, [variables, operator]);
 
-    return { results, loading };
+    return {
+        results,
+        loading,
+        dateRange,
+        dateRangeLoading,
+    };
 };

--- a/src/components/DateRangeFacet.jsx
+++ b/src/components/DateRangeFacet.jsx
@@ -1,6 +1,5 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import { EuiTitle } from "@elastic/eui";
-import { useSearchkit } from "@searchkit/client";
 import moment from "moment";
 import { LetterDateFilter } from "./LetterDateFilter";
 import { datesValid } from "../common";
@@ -13,72 +12,13 @@ import { datesValid } from "../common";
  * @param {moment.Moment} props.maxDate Max date returned from API, as a moment object
  * @param {moment.Moment} props.minDate Min date returned from API, as a moment object
  * @param {boolean} props.loading Loading indicator boolean
+ * @param {object} props.dateRange Current date range state
+ * @param {Function} props.setDateRange Function to set date range state
  * @returns {React.Component} Date range React component
  */
-function DateRangeFacet({ minDate, maxDate, loading }) {
-    // adapted from @searchkit/elastic-ui
-    const api = useSearchkit();
-    const startDateFilters = api.getFiltersByIdentifier("start_date");
-    const selectedStartDate = startDateFilters && startDateFilters[0];
-    const endDateFilters = api.getFiltersByIdentifier("end_date");
-    const selectedEndDate = endDateFilters && endDateFilters[0];
-
-    // if a filter already present on mount, set initial state to that range
-    const [dateRange, setDateRange] = useState({
-        startDate: selectedStartDate?.dateMin
-            ? moment(selectedStartDate.dateMin)
-            : null,
-        endDate: selectedEndDate?.dateMax
-            ? moment(selectedEndDate.dateMax)
-            : null,
-    });
-
-    // update filters when range is changed
-    useEffect(() => {
-        api.removeFiltersByIdentifier("start_date");
-        api.removeFiltersByIdentifier("end_date");
-        if (
-            dateRange
-            && (dateRange.startDate || dateRange.endDate)
-            && datesValid({ ...dateRange })
-        ) {
-            if (dateRange.startDate) {
-                api.addFilter({
-                    identifier: "start_date",
-                    dateMin: dateRange?.startDate?.toISOString(),
-                });
-            }
-            if (dateRange.endDate) {
-                api.addFilter({
-                    identifier: "end_date",
-                    dateMax: dateRange?.endDate?.toISOString(),
-                });
-            }
-        }
-        api.search();
-    }, [dateRange]);
-
-    useEffect(() => {
-        // handle search state generated from URL query params
-        if (
-            (selectedStartDate?.dateMin && !dateRange.startDate)
-            || (selectedEndDate?.dateMax && !dateRange.endDate)
-        ) {
-            setDateRange(() => ({
-                startDate: selectedStartDate?.dateMin
-                    ? moment(selectedStartDate.dateMin)
-                    : null,
-                endDate: selectedEndDate?.dateMax
-                    ? moment(selectedEndDate.dateMax)
-                    : null,
-            }));
-            api.search();
-        } else if (!api.getFilters().length && (dateRange.startDate || dateRange.endDate)) {
-            // handle "reset search" click
-            setDateRange({ startDate: null, endDate: null });
-        }
-    }, [selectedStartDate, selectedEndDate]);
-
+function DateRangeFacet({
+    minDate, maxDate, dateRange, setDateRange, loading,
+}) {
     return (
         <>
             <EuiTitle size="xxs">
@@ -86,7 +26,9 @@ function DateRangeFacet({ minDate, maxDate, loading }) {
             </EuiTitle>
             <LetterDateFilter
                 dateRange={dateRange}
-                isValid={datesValid({ ...dateRange })}
+                isValid={datesValid({
+                    ...dateRange,
+                })}
                 loading={loading}
                 minDate={minDate}
                 maxDate={maxDate}

--- a/src/components/DateRangeFacet.jsx
+++ b/src/components/DateRangeFacet.jsx
@@ -10,12 +10,12 @@ import { datesValid } from "../common";
  * ability to use minimum and maximum date aggregations across the dataset.
  *
  * @param {object} props React functional component props
- * @param {object} props.data Results from ElasticSearch, which should include min and max date
- * aggregations.
+ * @param {moment.Moment} props.maxDate Max date returned from API, as a moment object
+ * @param {moment.Moment} props.minDate Min date returned from API, as a moment object
  * @param {boolean} props.loading Loading indicator boolean
  * @returns {React.Component} Date range React component
  */
-function DateRangeFacet({ data, loading }) {
+function DateRangeFacet({ minDate, maxDate, loading }) {
     // adapted from @searchkit/elastic-ui
     const api = useSearchkit();
     const startDateFilters = api.getFiltersByIdentifier("start_date");
@@ -32,12 +32,6 @@ function DateRangeFacet({ data, loading }) {
             ? moment(selectedEndDate.dateMax)
             : null,
     });
-
-    // get min and max date facet values
-    const min = data?.facets?.find((f) => f.identifier === "min_date")?.value || null;
-    const minDate = min ? moment(min) : null;
-    const max = data?.facets?.find((f) => f.identifier === "max_date")?.value || null;
-    const maxDate = max ? moment(max) : null;
 
     // update filters when range is changed
     useEffect(() => {

--- a/src/components/LetterDateFilter.jsx
+++ b/src/components/LetterDateFilter.jsx
@@ -28,30 +28,34 @@ export function LetterDateFilter({
         <EuiDatePickerRange
             startDateControl={(
                 <EuiDatePicker
-                    selected={dateRange?.startDate}
-                    onClear={onChangeStart}
-                    onChange={onChangeStart}
-                    isLoading={loading}
-                    startDate={dateRange?.startDate}
-                    endDate={dateRange?.endDate}
-                    placeholder="from"
-                    isInvalid={!isValid}
                     aria-label="Start date"
+                    endDate={dateRange?.endDate}
+                    isInvalid={!isValid}
+                    isLoading={loading}
+                    minDate={minDate}
+                    maxDate={maxDate}
+                    onChange={onChangeStart}
+                    onClear={onChangeStart}
                     openToDate={dateRange?.startDate || minDate}
+                    placeholder="from"
+                    selected={dateRange?.startDate}
+                    startDate={dateRange?.startDate}
                 />
             )}
             endDateControl={(
                 <EuiDatePicker
-                    isLoading={loading}
-                    selected={dateRange?.endDate}
-                    onClear={onChangeEnd}
-                    onChange={onChangeEnd}
-                    startDate={dateRange?.startDate}
+                    aria-label="End date"
                     endDate={dateRange?.endDate}
                     isInvalid={!isValid}
-                    placeholder="to"
-                    aria-label="End date"
+                    isLoading={loading}
+                    minDate={minDate}
+                    maxDate={maxDate}
+                    onChange={onChangeEnd}
+                    onClear={onChangeEnd}
                     openToDate={dateRange?.endDate || maxDate}
+                    placeholder="to"
+                    selected={dateRange?.endDate}
+                    startDate={dateRange?.startDate}
                 />
             )}
         />

--- a/src/components/LetterDateFilter.jsx
+++ b/src/components/LetterDateFilter.jsx
@@ -30,6 +30,7 @@ export function LetterDateFilter({
                 <EuiDatePicker
                     aria-label="Start date"
                     endDate={dateRange?.endDate}
+                    dateFormat={["MM/DD/YYYY", "YYYY"]}
                     isInvalid={!isValid}
                     isLoading={loading}
                     minDate={minDate}
@@ -46,6 +47,7 @@ export function LetterDateFilter({
                 <EuiDatePicker
                     aria-label="End date"
                     endDate={dateRange?.endDate}
+                    dateFormat={["MM/DD/YYYY", "YYYY"]}
                     isInvalid={!isValid}
                     isLoading={loading}
                     minDate={minDate}

--- a/src/pages/EntitiesSearchPage/EntitiesSearchPage.jsx
+++ b/src/pages/EntitiesSearchPage/EntitiesSearchPage.jsx
@@ -135,7 +135,9 @@ function EntitiesSearch() {
                             </EuiPageContentBody>
                         ) : (
                             <EuiPageContentBody>
-                                Your search did not return any results.
+                                {loading
+                                    ? "Loading..."
+                                    : "Your search did not return any results."}
                             </EuiPageContentBody>
                         )}
                     </EuiPageContent>

--- a/src/pages/EntitiesSearchPage/entitiesSearchConfig.js
+++ b/src/pages/EntitiesSearchPage/entitiesSearchConfig.js
@@ -15,6 +15,7 @@ export const analyzers = ["searchkick_search", "searchkick_search2"];
 
 // Config for Searchkit SDK; see https://searchkit.co/docs/core/reference/searchkit-sdk
 export const entitiesSearchConfig = {
+    name: "entities",
     host: import.meta.env.VITE_SEARCHKIT_ENDPOINT,
     connectionOptions: {
         headers: {

--- a/src/pages/LettersSearchPage/LettersSearchPage.jsx
+++ b/src/pages/LettersSearchPage/LettersSearchPage.jsx
@@ -40,6 +40,7 @@ import withSearchRouting from "../../components/withSearchRouting";
 import "../../common/search.css";
 import { SearchControls } from "../../components/SearchControls";
 import { useCustomSearchkitSDK } from "../../common";
+import { useDateFilter } from "./useDateFilter";
 
 // icon component cache required for dynamically imported EUI icons in Vite;
 // see https://github.com/elastic/eui/issues/5463
@@ -62,6 +63,7 @@ appendIconComponentCache({
 function LettersSearch() {
     const [query, setQuery] = useSearchkitQueryValue();
     const [operator, setOperator] = useState("or");
+    const [dateRangeState, setDateRangeState] = useDateFilter();
     const [sortState, setSortState] = useState({
         field: "date",
         direction: 1,
@@ -122,6 +124,8 @@ function LettersSearch() {
                             minDate={dateRange?.minDate}
                             maxDate={dateRange?.maxDate}
                             loading={dateRangeLoading || loading}
+                            dateRange={dateRangeState}
+                            setDateRange={setDateRangeState}
                         />
                         <EuiSpacer size="l" />
                         {results?.facets
@@ -164,7 +168,15 @@ function LettersSearch() {
                             </EuiTitle>
                         </EuiPageHeaderSection>
                         <EuiPageHeaderSection>
-                            <ResetSearchButton loading={loading} />
+                            <ResetSearchButton
+                                loading={loading}
+                                onClick={() => {
+                                    // customize reset behavior to also reset date range
+                                    api.setQuery("");
+                                    setDateRangeState({ startDate: null, endDate: null });
+                                    api.search();
+                                }}
+                            />
                         </EuiPageHeaderSection>
                     </EuiPageHeader>
                     <EuiPageContent>

--- a/src/pages/LettersSearchPage/LettersSearchPage.jsx
+++ b/src/pages/LettersSearchPage/LettersSearchPage.jsx
@@ -91,7 +91,9 @@ function LettersSearch() {
         }
     }, [sortState]);
     const variables = useSearchkitVariables();
-    const { results, loading } = useCustomSearchkitSDK({
+    const {
+        results, loading, dateRange, dateRangeLoading,
+    } = useCustomSearchkitSDK({
         analyzers,
         config: lettersSearchConfig,
         fields,
@@ -116,7 +118,11 @@ function LettersSearch() {
                             query={query}
                         />
                         <EuiHorizontalRule margin="m" />
-                        <DateRangeFacet data={results} loading={loading} />
+                        <DateRangeFacet
+                            minDate={dateRange?.minDate}
+                            maxDate={dateRange?.maxDate}
+                            loading={dateRangeLoading}
+                        />
                         <EuiSpacer size="l" />
                         {results?.facets
                             .filter(

--- a/src/pages/LettersSearchPage/LettersSearchPage.jsx
+++ b/src/pages/LettersSearchPage/LettersSearchPage.jsx
@@ -121,7 +121,7 @@ function LettersSearch() {
                         <DateRangeFacet
                             minDate={dateRange?.minDate}
                             maxDate={dateRange?.maxDate}
-                            loading={dateRangeLoading}
+                            loading={dateRangeLoading || loading}
                         />
                         <EuiSpacer size="l" />
                         {results?.facets

--- a/src/pages/LettersSearchPage/LettersSearchPage.jsx
+++ b/src/pages/LettersSearchPage/LettersSearchPage.jsx
@@ -187,7 +187,9 @@ function LettersSearch() {
                             </EuiPageContentBody>
                         ) : (
                             <EuiPageContentBody>
-                                Your search did not return any results.
+                                {loading
+                                    ? "Loading..."
+                                    : "Your search did not return any results."}
                             </EuiPageContentBody>
                         )}
                     </EuiPageContent>

--- a/src/pages/LettersSearchPage/lettersSearchConfig.js
+++ b/src/pages/LettersSearchPage/lettersSearchConfig.js
@@ -18,6 +18,7 @@ export const analyzers = ["searchkick_search", "searchkick_search2"];
 
 // Config for Searchkit SDK; see https://searchkit.co/docs/core/reference/searchkit-sdk
 export const lettersSearchConfig = {
+    name: "letters",
     host: import.meta.env.VITE_SEARCHKIT_ENDPOINT,
     connectionOptions: {
         headers: {

--- a/src/pages/LettersSearchPage/useDateFilter.js
+++ b/src/pages/LettersSearchPage/useDateFilter.js
@@ -1,0 +1,76 @@
+import { useState, useEffect } from "react";
+import moment from "moment";
+import { useSearchkit } from "@searchkit/client";
+import { datesValid } from "../../common";
+
+/**
+ * Hook to abstract date filter state management away from the Letters search page component.
+ * Interfaces with Searchkit API to validate, read, and write start/end date filters; handles
+ * search URL query params; and uses effects to ensure synchronization between frontend state
+ * and Searchkit search state.
+ *
+ * @returns {Array<object, Function>} An array containing the current date frontend state and
+ * the setState function for it.
+ */
+export function useDateFilter() {
+    const api = useSearchkit();
+    const startDateFilters = api.getFiltersByIdentifier("start_date");
+    const selectedStartDate = startDateFilters && startDateFilters[0];
+    const endDateFilters = api.getFiltersByIdentifier("end_date");
+    const selectedEndDate = endDateFilters && endDateFilters[0];
+
+    // if a filter already present on initialization, set initial state to that range
+    const [dateRange, setDateRange] = useState({
+        startDate: selectedStartDate?.dateMin
+            ? moment(selectedStartDate.dateMin)
+            : null,
+        endDate: selectedEndDate?.dateMax
+            ? moment(selectedEndDate.dateMax)
+            : null,
+    });
+
+    // update filters when range is changed (to a valid range)
+    useEffect(() => {
+        api.removeFiltersByIdentifier("start_date");
+        api.removeFiltersByIdentifier("end_date");
+        if (
+            dateRange
+            && (dateRange.startDate || dateRange.endDate)
+            && datesValid({ ...dateRange })
+        ) {
+            if (dateRange.startDate) {
+                api.addFilter({
+                    identifier: "start_date",
+                    dateMin: dateRange?.startDate?.toISOString(),
+                });
+            }
+            if (dateRange.endDate) {
+                api.addFilter({
+                    identifier: "end_date",
+                    dateMax: dateRange?.endDate?.toISOString(),
+                });
+            }
+        }
+        api.search();
+    }, [dateRange]);
+
+    // handle search state generated from URL query params
+    useEffect(() => {
+        if (
+            (selectedStartDate?.dateMin && !dateRange.startDate)
+            || (selectedEndDate?.dateMax && !dateRange.endDate)
+        ) {
+            setDateRange(() => ({
+                startDate: selectedStartDate?.dateMin
+                    ? moment(selectedStartDate.dateMin)
+                    : null,
+                endDate: selectedEndDate?.dateMax
+                    ? moment(selectedEndDate.dateMax)
+                    : null,
+            }));
+            api.search();
+        }
+    }, [selectedStartDate, selectedEndDate]);
+
+    return [dateRange, setDateRange];
+}


### PR DESCRIPTION
## In this PR

- Per meeting and #14:
  - Constrain dates to global min and max across data
    - Use a separate Elasticsearch request with an aggregation, but without filters, in `useCustomSearchkitSDK` to ensure the true min and max dates are always available despite any entered query/filters/etc
    - Add `minDate` and `maxDate` props to `EuiDatePicker` to force users to pick within the range
  - Allow typing only a year in the date range filter component
    - Add the format `"YYYY"` to the allowed formats, which will default to `01/01/YYYY` for the entered year
    - Move Searchkit search state + frontend date state synchronization out of date range filter component and into its own `useDateFilter` hook (keeps component itself stateless and more modular)
    - Bump our fork of `searchkit/elastic-ui` to allow the extra prop `onClick` on `ResetSearchButton`, which allows us to properly clear the frontend date state (this was not working properly before)