### PR TITLE
Use UTC when formatting dates

### DIFF
--- a/src/common/dateUtil.js
+++ b/src/common/dateUtil.js
@@ -11,8 +11,9 @@ export const formatDate = (date) => {
     const d = new Date(date);
     const month = new Intl.DateTimeFormat("en-US", {
         month: "long",
+        timeZone: "UTC",
     }).format(d);
-    return `${d.getDate()} ${month} ${d.getFullYear()}`;
+    return `${d.getUTCDate()} ${month} ${d.getUTCFullYear()}`;
 };
 
 /**


### PR DESCRIPTION
Formatted dates were being displayed relative to UTC. This resulted in them appearing one day early.