### PR TITLE
Superscript should be super

### DIFF
--- a/src/assets/index.css
+++ b/src/assets/index.css
@@ -13,3 +13,6 @@
 .capital-label {
     text-transform: capitalize;
 }
+sup {
+    vertical-align: super !important;
+}


### PR DESCRIPTION
It looks like EUI uses [Emotion CSS.](https://emotion.sh/docs/introduction) which vertically aligns `<sup>` elements to the baseline. This is not desired. My solution here is rather hamfisted. Feel free to close this if you would prefer this rule to live elsewhere.