### PR TITLE
Persist filters on Entity related letters (#47)

### DIFF
--- a/src/pages/EntitiesSearchPage/EntitiesSearchPage.jsx
+++ b/src/pages/EntitiesSearchPage/EntitiesSearchPage.jsx
@@ -78,7 +78,7 @@ function EntitiesSearch() {
             api.setSearchState(routeToState(searchParams));
             api.search();
         }
-    }, []);
+    }, [searchParams]);
     useEffect(() => {
         if (variables) {
             setSearchParams(stateToRoute(variables));

--- a/src/pages/EntityPage/EntityPage.jsx
+++ b/src/pages/EntityPage/EntityPage.jsx
@@ -101,6 +101,7 @@ export function EntityPage() {
                                                 title={
                                                     relatedLettersMapping[key]
                                                 }
+                                                type={key}
                                                 uri={value}
                                             />
                                         </React.Fragment>

--- a/src/pages/LettersSearchPage/LettersSearchPage.jsx
+++ b/src/pages/LettersSearchPage/LettersSearchPage.jsx
@@ -122,7 +122,7 @@ function LettersSearch() {
             }
             api.search();
         }
-    }, []);
+    }, [searchParams]);
     useEffect(() => {
         if (variables) {
             setSearchParams(stateToRoute({


### PR DESCRIPTION
## In this PR

- Per #47 and #28:
  - Add search params to individual Entity records pages to ensure letter filter states (pagination and date filters) are persisted when clicking "Back"
- Per #28:
  - Fix an issue where clicking "Back" to the search pages would result in some search params getting clobbered (for some reason always the `from` key?)