### PR TITLE
Allow searching entities by label (#22, #23)

### DIFF
--- a/src/pages/EntitiesSearchPage/EntitiesSearchPage.jsx
+++ b/src/pages/EntitiesSearchPage/EntitiesSearchPage.jsx
@@ -37,6 +37,7 @@ import {
     analyzers,
     entitiesSearchConfig,
     fields,
+    scopeOptions,
 } from "./entitiesSearchConfig";
 import EntitiesResults from "../../components/EntitiesResults";
 import ListFacet from "../../components/ListFacet";
@@ -61,6 +62,7 @@ appendIconComponentCache({
 function EntitiesSearch() {
     const [query, setQuery] = useSearchkitQueryValue();
     const [operator, setOperator] = useState("or");
+    const [scope, setScope] = useState("keyword");
     const api = useSearchkit();
     const variables = useSearchkitVariables();
     const { results, loading } = useCustomSearchkitSDK({
@@ -69,6 +71,7 @@ function EntitiesSearch() {
         fields,
         operator,
         variables,
+        scope,
     });
 
     // Use React Router useSearchParams to translate to and from URL query params
@@ -76,12 +79,18 @@ function EntitiesSearch() {
     useEffect(() => {
         if (api && searchParams) {
             api.setSearchState(routeToState(searchParams));
+            if (searchParams.has("scope")) {
+                setScope(searchParams.get("scope"));
+            }
             api.search();
         }
     }, []);
     useEffect(() => {
         if (variables) {
-            setSearchParams(stateToRoute(variables));
+            setSearchParams(stateToRoute({
+                ...variables,
+                scope,
+            }));
         }
     }, [variables]);
     return (
@@ -100,6 +109,9 @@ function EntitiesSearch() {
                             setOperator={setOperator}
                             setQuery={setQuery}
                             query={query}
+                            scopeOptions={scopeOptions}
+                            scope={scope}
+                            setScope={setScope}
                         />
                         <EuiHorizontalRule margin="m" />
                         {results?.facets.map((facet) => (

--- a/src/pages/EntitiesSearchPage/entitiesSearchConfig.js
+++ b/src/pages/EntitiesSearchPage/entitiesSearchConfig.js
@@ -3,8 +3,8 @@ import { buildQuery } from "../../common";
 
 // kewyord field names to search on
 export const fields = [
-    { name: "short_display", boost: 20 },
-    { name: "clean_label", boost: 10 },
+    { name: "clean_label", boost: 20 },
+    { name: "short_display", boost: 10 },
     { name: "clean_description", boost: 5 },
     { name: "alternate_names", boost: 9 },
     { name: "alternate_spellings", boost: 8 },

--- a/src/pages/EntitiesSearchPage/entitiesSearchConfig.js
+++ b/src/pages/EntitiesSearchPage/entitiesSearchConfig.js
@@ -10,6 +10,13 @@ export const fields = [
     { name: "alternate_spellings", boost: 8 },
 ];
 
+// search scopes (keyword search, label search)
+// values besides "keyword" must match names of fields in the index
+export const scopeOptions = [
+    { value: "keyword", text: "Keyword" },
+    { value: "clean_label", text: "Label" },
+];
+
 // search analyzers from seachkick, see
 // https://www.rubydoc.info/gems/searchkick/0.1.3/Searchkick%2FSearch:search
 export const analyzers = ["searchkick_search", "searchkick_search2"];


### PR DESCRIPTION
## In this PR

- Boost `clean_label` for keyword search; seems to be more relevant than `short_display` generally. (Was having trouble finding Paris otherwise!)
- Per #22, #23:
  - Use agreed-upon "label" scope for entities search