### PR TITLE
Refactor URL routing (#28)

### DIFF
--- a/src/common/index.js
+++ b/src/common/index.js
@@ -4,4 +4,5 @@ export * from "./fetch";
 export * from "./queryBuilder";
 export * from "./searchRouting";
 export * from "./useCustomSearchkitSDK";
+export * from "./useScope";
 export * from "./volumeLabels";

--- a/src/common/searchRouting.js
+++ b/src/common/searchRouting.js
@@ -109,3 +109,17 @@ export function routeToState(route) {
     }
     return searchState;
 }
+
+/**
+ * Check if the passed search state is the default search state, so that it does not
+ * overwrite non-default state.
+ *
+ * @param {object} state The search state to check
+ * @returns {boolean} True if the search state is the default, false if not
+ */
+export function isDefault(state) {
+    return !state.query
+    && (!state.filters || state.filters.length === 0)
+    && !state.sortBy
+    && state.page?.from === 0;
+}

--- a/src/common/searchRouting.js
+++ b/src/common/searchRouting.js
@@ -15,6 +15,7 @@ export function stateToRoute(searchState) {
         size: Number(searchState.page?.size) || 25,
         from: Number(searchState.page?.from),
         scope: searchState.scope,
+        op: searchState.operator,
     };
     searchState.filters.forEach((filter) => {
         // simplify filter representation
@@ -64,19 +65,21 @@ export function routeToState(route) {
             from: Number(route.get("from")) || 0,
         },
         scope: route.get("scope") || "",
+        operator: route.get("op") || "",
         filters: [],
     };
     // get filters state back into format expected by Searchkit
     Array.from(route.entries())
         .filter(
             ([key, _val]) => ![
-                "query", // only process filters, not query/sort/size/from
+                "query", // only process filters, not query/sort/size/from/scope/operator
                 "sort",
                 "size",
                 "from",
-                "dateMin", // handle date filters separately
-                "dateMax",
                 "scope",
+                "op",
+                "dateMin", // also handle date filters separately
+                "dateMax",
             ].includes(key),
         )
         .forEach(([identifier, val]) => {
@@ -120,6 +123,7 @@ export function routeToState(route) {
 export function isDefault(state) {
     return !state.query
     && (!state.filters || state.filters.length === 0)
-    && !state.sortBy
+    && (!state.sortBy || state.sortBy === "date_asc")
+    && (!state.operator || state.operator === "or")
     && state.page?.from === 0;
 }

--- a/src/common/useCustomSearchkitSDK.js
+++ b/src/common/useCustomSearchkitSDK.js
@@ -20,7 +20,6 @@ export const useCustomSearchkitSDK = ({
     config,
     analyzers,
     fields,
-    operator,
 }) => {
     const [results, setResponse] = useState(null);
     const [loading, setLoading] = useState(true);
@@ -59,7 +58,7 @@ export const useCustomSearchkitSDK = ({
     // other requests with filters applied, if/whenever they change
     useEffect(() => {
         // eslint-disable-next-line jsdoc/require-jsdoc
-        async function fetchData(vars, oper) {
+        async function fetchData(vars) {
             setLoading(true);
             const request = createInstance({
                 ...config,
@@ -69,7 +68,7 @@ export const useCustomSearchkitSDK = ({
                         !vars.scope || vars.scope === "keyword"
                             ? fields
                             : [{ name: vars.scope, boost: 10 }],
-                    operator: oper,
+                    operator: vars.operator || "or",
                 }),
             })
                 .query(vars.query)
@@ -86,10 +85,10 @@ export const useCustomSearchkitSDK = ({
             setLoading(false);
             setResponse(response);
         }
-        if (searchParams && operator) {
-            fetchData(routeToState(searchParams), operator);
+        if (searchParams) {
+            fetchData(routeToState(searchParams));
         }
-    }, [searchParams, operator]);
+    }, [searchParams]);
 
     return {
         results,

--- a/src/common/useScope.js
+++ b/src/common/useScope.js
@@ -1,0 +1,51 @@
+import { useSearchkitVariables } from "@searchkit/client";
+import { useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import { isDefault, stateToRoute } from "./searchRouting";
+
+/**
+ * Utility hook to factor out two repeated concepts between the search pages:
+ * - The "scope" state defaults and side effects
+ * - Updating URL search params when Searchkit Variables change
+ * Calling it useScope since we only actually need to return the scope state and setter.
+ *
+ * @returns {Array<object, Function>} An array containing the current scope frontend state and
+ * the setState function for it.
+ */
+export const useScope = () => {
+    const variables = useSearchkitVariables();
+    const [searchParams, setSearchParams] = useSearchParams();
+
+    const [scope, setScope] = useState(() => {
+        if (searchParams.has("scope")) {
+            return searchParams.get("scope");
+        }
+        // default scope: keyword
+        return "keyword";
+    });
+    useEffect(() => {
+        // don't auto-update search params when loading the defaults;
+        // if we need to reset, do it manually (i.e. reset button or unclicking filters)
+        if (variables && !isDefault(variables)) {
+            setSearchParams((prevParams) => {
+                let page = {};
+                // reset page to 0 if scope changes; could filter out results
+                if (!prevParams.has("scope") || scope !== prevParams.get("scope")) {
+                    page = {
+                        page: {
+                            from: 0,
+                            size: 25,
+                        },
+                    };
+                }
+                return stateToRoute({
+                    ...variables,
+                    ...page,
+                    scope,
+                });
+            });
+        }
+    }, [variables, scope]);
+
+    return [scope, setScope];
+};

--- a/src/components/ListFacet.css
+++ b/src/components/ListFacet.css
@@ -5,7 +5,10 @@
     margin-bottom: 0;
     margin-right: 5px;
 }
-.list-facet .facet-group .facet-button:hover a {
+.list-facet .facet-group .facet-button span.capital-label {
+    color: var(--primary-dark);
+}
+.list-facet .facet-group .facet-button:hover span.capital-label {
     text-decoration: underline;
 }
 .list-facet:not(:first-child) {

--- a/src/components/ValueFilter.jsx
+++ b/src/components/ValueFilter.jsx
@@ -1,7 +1,7 @@
 import { EuiButton, EuiFlexItem } from "@elastic/eui";
-import { FilterLink } from "@searchkit/client";
-import { useRef } from "react";
-import { volumeLabels } from "../common";
+import { useSearchkit, useSearchkitVariables } from "@searchkit/client";
+import { useSearchParams } from "react-router-dom";
+import { stateToRoute, volumeLabels } from "../common";
 
 // eslint-disable-next-line jsdoc/require-param, jsdoc/require-returns
 /**
@@ -9,7 +9,9 @@ import { volumeLabels } from "../common";
  * https://github.com/searchkit/searchkit/blob/a67420cb1e16d2a459f473c904cde10b3cfd5858/packages/searchkit-elastic-ui/src/SelectedFilters/index.tsx#L46
  */
 function ValueFilter({ filter, loading }) {
-    const ref = useRef();
+    const api = useSearchkit();
+    const variables = useSearchkitVariables();
+    const [_, setSearchParams] = useSearchParams();
     let valueLabel = filter.value;
     // special handling for volume labels
     if (
@@ -25,13 +27,26 @@ function ValueFilter({ filter, loading }) {
                 iconSide="right"
                 iconType="cross"
                 isLoading={loading}
-                onClick={(e) => {
-                    ref.current.onClick(e);
+                onClick={() => {
+                    const filters = api
+                        .getFilters()
+                        .filter((f) => !(
+                            f.value === filter.value && f.identifier === filter.identifier
+                        ));
+                    setSearchParams(
+                        stateToRoute({
+                            ...variables,
+                            filters,
+                            page: {
+                                from: 0,
+                            },
+                        }),
+                    );
                 }}
             >
-                <FilterLink ref={ref} filter={filter}>
+                <span>
                     {`${filter.label}: ${valueLabel}`}
-                </FilterLink>
+                </span>
             </EuiButton>
         </EuiFlexItem>
     );

--- a/src/pages/EntitiesSearchPage/EntitiesSearchPage.jsx
+++ b/src/pages/EntitiesSearchPage/EntitiesSearchPage.jsx
@@ -64,7 +64,7 @@ appendIconComponentCache({
 function EntitiesSearch() {
     const [searchParams, setSearchParams] = useSearchParams();
     const [query, setQuery] = useState(() => (searchParams.has("query") ? searchParams.get("query") : ""));
-    const [operator, setOperator] = useState("or");
+    const [operator, setOperator] = useState(searchParams.has("op") ? searchParams.get("op") : "or");
     const [scope, setScope] = useScope();
     const api = useSearchkit();
     const variables = useSearchkitVariables();
@@ -72,7 +72,6 @@ function EntitiesSearch() {
         analyzers,
         config: entitiesSearchConfig,
         fields,
-        operator,
     });
 
     // Use React Router useSearchParams to translate to and from URL query params
@@ -82,6 +81,20 @@ function EntitiesSearch() {
             api.search();
         }
     }, [searchParams]);
+    useEffect(() => {
+        if (operator && searchParams && (!searchParams.has("op") || searchParams.get("op") !== operator)) {
+            setSearchParams(
+                stateToRoute({
+                    ...variables,
+                    scope,
+                    operator,
+                    page: {
+                        from: 0, // reset page to 0 on operator change; could exclude results!
+                    },
+                }),
+            );
+        }
+    }, [operator]);
 
     return (
         <main className="search-page">
@@ -96,6 +109,7 @@ function EntitiesSearch() {
                                     stateToRoute({
                                         ...variables,
                                         scope,
+                                        operator,
                                         query: value,
                                         page: {
                                             from: 0,

--- a/src/pages/EntitiesSearchPage/EntitiesSearchPage.jsx
+++ b/src/pages/EntitiesSearchPage/EntitiesSearchPage.jsx
@@ -3,15 +3,10 @@ import { useSearchParams } from "react-router-dom";
 import {
     SearchkitClient,
     useSearchkit,
-    useSearchkitQueryValue,
     useSearchkitVariables,
     withSearchkit,
 } from "@searchkit/client";
-import {
-    ResetSearchButton,
-    SelectedFilters,
-    Pagination,
-} from "@ecds/searchkit-elastic-ui";
+import { Pagination } from "@ecds/searchkit-elastic-ui";
 import {
     EuiPage,
     EuiPageBody,
@@ -25,6 +20,7 @@ import {
     EuiTitle,
     EuiHorizontalRule,
     EuiFlexGroup,
+    EuiButton,
 } from "@elastic/eui";
 import "@elastic/eui/dist/eui_theme_light.css";
 import { appendIconComponentCache } from "@elastic/eui/es/components/icon/icon";
@@ -42,7 +38,13 @@ import {
 import EntitiesResults from "../../components/EntitiesResults";
 import ListFacet from "../../components/ListFacet";
 import { SearchControls } from "../../components/SearchControls";
-import { routeToState, stateToRoute, useCustomSearchkitSDK } from "../../common";
+import {
+    routeToState,
+    stateToRoute,
+    useCustomSearchkitSDK,
+    useScope,
+} from "../../common";
+import ValueFilter from "../../components/ValueFilter";
 
 // icon component cache required for dynamically imported EUI icons in Vite;
 // see https://github.com/elastic/eui/issues/5463
@@ -60,9 +62,10 @@ appendIconComponentCache({
  * @returns React entities search page component
  */
 function EntitiesSearch() {
-    const [query, setQuery] = useSearchkitQueryValue();
+    const [searchParams, setSearchParams] = useSearchParams();
+    const [query, setQuery] = useState(() => (searchParams.has("query") ? searchParams.get("query") : ""));
     const [operator, setOperator] = useState("or");
-    const [scope, setScope] = useState("keyword");
+    const [scope, setScope] = useScope();
     const api = useSearchkit();
     const variables = useSearchkitVariables();
     const { results, loading } = useCustomSearchkitSDK({
@@ -70,29 +73,16 @@ function EntitiesSearch() {
         config: entitiesSearchConfig,
         fields,
         operator,
-        variables,
-        scope,
     });
 
     // Use React Router useSearchParams to translate to and from URL query params
-    const [searchParams, setSearchParams] = useSearchParams();
     useEffect(() => {
         if (api && searchParams) {
             api.setSearchState(routeToState(searchParams));
-            if (searchParams.has("scope")) {
-                setScope(searchParams.get("scope"));
-            }
             api.search();
         }
     }, [searchParams]);
-    useEffect(() => {
-        if (variables) {
-            setSearchParams(stateToRoute({
-                ...variables,
-                scope,
-            }));
-        }
-    }, [variables]);
+
     return (
         <main className="search-page">
             <EuiPage paddingSize="l">
@@ -102,8 +92,16 @@ function EntitiesSearch() {
                             loading={loading}
                             onSearch={(value) => {
                                 setQuery(value);
-                                api.setQuery(value);
-                                api.search();
+                                setSearchParams(
+                                    stateToRoute({
+                                        ...variables,
+                                        scope,
+                                        query: value,
+                                        page: {
+                                            from: 0,
+                                        },
+                                    }),
+                                );
                             }}
                             operator={operator}
                             setOperator={setOperator}
@@ -127,14 +125,42 @@ function EntitiesSearch() {
                     <EuiPageHeader>
                         <EuiPageHeaderSection className="active-facet-group">
                             <EuiTitle size="l">
-                                <SelectedFilters
-                                    data={results}
-                                    loading={loading}
-                                />
+                                <EuiFlexGroup
+                                    gutterSize="s"
+                                    alignItems="center"
+                                >
+                                    {results?.summary?.appliedFilters.map(
+                                        (filter) => (
+                                            <ValueFilter
+                                                key={filter.id}
+                                                filter={filter}
+                                                loading={loading}
+                                            />
+                                        ),
+                                    )}
+                                </EuiFlexGroup>
                             </EuiTitle>
                         </EuiPageHeaderSection>
                         <EuiPageHeaderSection>
-                            <ResetSearchButton loading={loading} />
+                            <EuiButton
+                                fill
+                                color="text"
+                                className="reset-search"
+                                disabled={!api.canResetSearch()}
+                                isLoading={loading}
+                                onClick={() => {
+                                    // reset query and filters
+                                    setQuery("");
+                                    setSearchParams(
+                                        stateToRoute({
+                                            filters: [],
+                                            query: "",
+                                        }),
+                                    );
+                                }}
+                            >
+                                Reset Search
+                            </EuiButton>
                         </EuiPageHeaderSection>
                     </EuiPageHeader>
                     <EuiPageContent>

--- a/src/pages/LettersSearchPage/LettersSearchPage.jsx
+++ b/src/pages/LettersSearchPage/LettersSearchPage.jsx
@@ -74,10 +74,10 @@ appendIconComponentCache({
  */
 function LettersSearch() {
     const [searchParams, setSearchParams] = useSearchParams();
-    const [operator, setOperator] = useState("or");
+    const [query, setQuery] = useState(() => (searchParams.has("query") ? searchParams.get("query") : ""));
+    const [operator, setOperator] = useState(searchParams.has("op") ? searchParams.get("op") : "or");
     const [dateRangeState, setDateRangeState] = useDateFilter();
     const [scope, setScope] = useScope();
-    const [query, setQuery] = useState(() => (searchParams.has("query") ? searchParams.get("query") : ""));
     const [sortState, setSortState] = useState(() => {
         if (searchParams?.has("sort")) {
             const [field, dir] = searchParams.get("sort").split("_");
@@ -133,13 +133,29 @@ function LettersSearch() {
                 setSearchParams(
                     stateToRoute({
                         ...variables,
-                        scope,
+                        query,
                         sortBy,
+                        scope,
+                        operator,
                     }),
                 );
             }
         }
     }, [sortState]);
+    useEffect(() => {
+        if (operator && searchParams && (!searchParams.has("op") || searchParams.get("op") !== operator)) {
+            setSearchParams(
+                stateToRoute({
+                    ...variables,
+                    scope,
+                    operator,
+                    page: {
+                        from: 0, // reset page to 0 on operator change; could exclude results!
+                    },
+                }),
+            );
+        }
+    }, [operator]);
 
     return (
         <main className="search-page">
@@ -154,6 +170,7 @@ function LettersSearch() {
                                     stateToRoute({
                                         ...variables,
                                         scope,
+                                        operator,
                                         query: value,
                                         page: {
                                             from: 0,


### PR DESCRIPTION
## In this PR

To fix a [bug found](https://trello.com/c/4grDoOy7/29-search-back-button#comment-63920720572adc00820a6d97) in testing #28, this PR refactors the URL search state routing so that the flow is always as follows:

- Initialization: Any parameters are present in URL route on load ➡️ set searchkit state, conduct a search, and set the initial state of all the frontend components (filters, sort, query)
- Action: User interacts to change a filter, sort, scope, query, or other search option ➡️ change only the URL parameters 
- Action: Any URL parameters change ➡️ change searchkit state and conduct a search

This prevents issues where several of these things were overwriting values from others, because the flow was going in multiple directions in some cases. Conceptually, this PR shifts the source of truth on our frontend to the URL parameters, while searchkit state changes and calls to the API only ever happen when those URL parameters change.