### PR TITLE
Display additional letter metadata sections

### DIFF
--- a/src/components/LetterMetadata.jsx
+++ b/src/components/LetterMetadata.jsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { EuiTitle } from "@elastic/eui";
 
 /**
  * Letter metadata section component
@@ -12,12 +11,9 @@ import { EuiTitle } from "@elastic/eui";
 export function LetterMetadata({ metadata, excluded }) {
     return (
         <section>
-            <EuiTitle>
-                <h2 className="result-meta-heading">Letter Information</h2>
-            </EuiTitle>
             <dl className="letter-metadata">
                 {Object.entries(metadata).map(
-                    ([key, value]) => !excluded.includes(key)
+                    ([key, value]) => !excluded?.includes(key)
                         && value && (
                         <React.Fragment key={key}>
                             <dt className="capital-label">

--- a/src/pages/LetterPage/LetterPage.jsx
+++ b/src/pages/LetterPage/LetterPage.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/no-danger */
 import {
     EuiButtonEmpty,
+    EuiHorizontalRule,
     EuiPage,
     EuiPageBody,
     EuiPageContent,
@@ -70,12 +71,30 @@ export function LetterPage() {
                         </EuiPageHeaderSection>
                     </EuiPageHeader>
                     <EuiPageContent>
+                        <EuiTitle>
+                            <h2 className="result-meta-heading">Letter Information</h2>
+                        </EuiTitle>
                         {letter.metadata && (
                             <LetterMetadata
                                 metadata={letter.metadata}
                                 excluded={excludedMeta}
                             />
                         )}
+                        <EuiHorizontalRule />
+                        {letter.repositories && (
+                            <LetterMetadata
+                                metadata={letter.repositories}
+                            />
+                        )}
+                        <EuiHorizontalRule />
+                        {letter.publication_information && (
+                            <LetterMetadata
+                                metadata={{
+                                    publication_information: letter.publication_information,
+                                }}
+                            />
+                        )}
+                        <EuiHorizontalRule />
                         {letter.mentions && (
                             <LetterMentions mentions={letter.mentions} />
                         )}


### PR DESCRIPTION
Not sure if you have already addressed the additional letter metadata blocks. I'm also happy to rework or disregard if there is a better way to achieve the goal.