### PR TITLE
Explicit error messages, improved date validation (#54)

### DIFF
--- a/src/common/dateUtil.js
+++ b/src/common/dateUtil.js
@@ -22,14 +22,8 @@ export const formatDate = (date) => {
  * @param {object} dates Destructured arguments object
  * @param {moment.Moment} dates.startDate Moment object for start date from date picker
  * @param {moment.Moment} dates.endDate Moment object for end date from date picker
- * @param {moment.Moment} dates.min Min date returned from API, converted to Moment object
- * @param {moment.Moment} dates.max Max date returned from API, converted to Moment object
  * @returns True if no start/end dates are present or if all dates are valid
  */
 export const datesValid = ({
-    startDate, endDate, min, max,
-}) => (startDate && endDate ? startDate <= endDate : true)
-    && (startDate && max ? startDate <= max : true)
-    && (startDate && min ? startDate >= min : true)
-    && (endDate && max ? endDate <= max : true)
-    && (endDate && min ? endDate >= min : true);
+    startDate, endDate,
+}) => (startDate && endDate ? startDate <= endDate : true);

--- a/src/components/DateRangeFacet.jsx
+++ b/src/components/DateRangeFacet.jsx
@@ -26,9 +26,7 @@ function DateRangeFacet({
             </EuiTitle>
             <LetterDateFilter
                 dateRange={dateRange}
-                isValid={datesValid({
-                    ...dateRange,
-                })}
+                isValid={datesValid(dateRange)}
                 loading={loading}
                 minDate={minDate}
                 maxDate={maxDate}

--- a/src/components/EntityRelatedLetters.jsx
+++ b/src/components/EntityRelatedLetters.jsx
@@ -49,14 +49,7 @@ export function EntityRelatedLetters({ title, type, uri }) {
     // validate date range before actually making a date filter API call
     useEffect(() => {
         if (
-            dateRange
-            && data?.min_date
-            && data.max_date
-            && datesValid({
-                ...dateRange,
-                min: moment(data.min_date),
-                max: moment(data.max_date),
-            })
+            dateRange && datesValid(dateRange)
         ) {
             setFilterState((prevState) => ({
                 ...prevState,
@@ -137,11 +130,7 @@ export function EntityRelatedLetters({ title, type, uri }) {
                     <LetterDateFilter
                         minDate={moment(data.min_date)}
                         maxDate={moment(data.max_date)}
-                        isValid={datesValid({
-                            ...dateRange,
-                            min: moment(data.min_date),
-                            max: moment(data.max_date),
-                        })}
+                        isValid={datesValid(dateRange)}
                         loading={loading}
                         dateRange={dateRange}
                         onChangeStart={(d) => {

--- a/src/components/EntityRelatedLetters.jsx
+++ b/src/components/EntityRelatedLetters.jsx
@@ -48,9 +48,7 @@ export function EntityRelatedLetters({ title, type, uri }) {
 
     // validate date range before actually making a date filter API call
     useEffect(() => {
-        if (
-            dateRange && datesValid(dateRange)
-        ) {
+        if (dateRange && datesValid(dateRange)) {
             setFilterState((prevState) => ({
                 ...prevState,
                 ...dateRange,
@@ -77,9 +75,12 @@ export function EntityRelatedLetters({ title, type, uri }) {
                 ? moment(filterState.endDate).format(dateFormat)
                 : undefined,
         };
-        // remove any undefined key/value pairs
+        // remove (and keep track of) any undefined key/value pairs
+        const deleted = [];
         Object.keys(params).forEach(
-            (key) => params[key] === undefined && delete params[key],
+            (key) => params[key] === undefined
+                && deleted.push(`${type}_${key}`)
+                && delete params[key],
         );
         /**
          * Asynchronously fetch the related letters matching the params
@@ -106,15 +107,12 @@ export function EntityRelatedLetters({ title, type, uri }) {
             const prevParamsObj = {};
             // have to do it like this because URISearchParams can't use spread operator
             prevParams.forEach((value, key) => {
-                if (
-                    !Object.prototype.hasOwnProperty.call(
-                        updatedSearchParams,
-                        key,
-                    )
-                ) {
+                if (!Object.prototype.hasOwnProperty.call(updatedSearchParams, key)) {
                     prevParamsObj[key] = value;
                 }
             });
+            // also remove old params that have been deleted
+            deleted.forEach((del) => delete prevParamsObj[del]);
             // now we can use spread :)
             return { ...prevParamsObj, ...updatedSearchParams };
         }, { replace: true }); // don't push another entry onto the history stack!

--- a/src/components/LetterDateFilter.jsx
+++ b/src/components/LetterDateFilter.jsx
@@ -1,4 +1,6 @@
-import { EuiDatePicker, EuiDatePickerRange } from "@elastic/eui";
+import {
+    EuiDatePicker, EuiDatePickerRange, EuiSpacer, EuiText,
+} from "@elastic/eui";
 import moment from "moment";
 import React from "react";
 
@@ -25,41 +27,50 @@ export function LetterDateFilter({
     onChangeStart,
 }) {
     return (
-        <EuiDatePickerRange
-            startDateControl={(
-                <EuiDatePicker
-                    aria-label="Start date"
-                    endDate={dateRange?.endDate}
-                    dateFormat={["MM/DD/YYYY", "YYYY"]}
-                    isInvalid={!isValid}
-                    isLoading={loading}
-                    minDate={minDate}
-                    maxDate={maxDate}
-                    onChange={onChangeStart}
-                    onClear={onChangeStart}
-                    openToDate={dateRange?.startDate || minDate}
-                    placeholder="from"
-                    selected={dateRange?.startDate}
-                    startDate={dateRange?.startDate}
-                />
+        <div>
+            <EuiDatePickerRange
+                startDateControl={(
+                    <EuiDatePicker
+                        aria-label="Start date"
+                        endDate={dateRange?.endDate}
+                        dateFormat={["MM/DD/YYYY", "YYYY"]}
+                        isInvalid={!isValid}
+                        isLoading={loading}
+                        minDate={minDate}
+                        maxDate={maxDate}
+                        onChange={onChangeStart}
+                        onClear={onChangeStart}
+                        openToDate={dateRange?.startDate || minDate}
+                        placeholder="from"
+                        selected={dateRange?.startDate}
+                        startDate={dateRange?.startDate}
+                    />
+                )}
+                endDateControl={(
+                    <EuiDatePicker
+                        aria-label="End date"
+                        endDate={dateRange?.endDate}
+                        dateFormat={["MM/DD/YYYY", "YYYY"]}
+                        isInvalid={!isValid}
+                        isLoading={loading}
+                        minDate={minDate}
+                        maxDate={maxDate}
+                        onChange={onChangeEnd}
+                        onClear={onChangeEnd}
+                        openToDate={dateRange?.endDate || maxDate}
+                        placeholder="to"
+                        selected={dateRange?.endDate}
+                        startDate={dateRange?.startDate}
+                    />
+                )}
+            />
+            {!isValid && (
+                <>
+                    <EuiSpacer size="s" />
+                    <EuiText color="danger" size="s">Error: Start date cannot be later than end date.</EuiText>
+                    <EuiSpacer size="s" />
+                </>
             )}
-            endDateControl={(
-                <EuiDatePicker
-                    aria-label="End date"
-                    endDate={dateRange?.endDate}
-                    dateFormat={["MM/DD/YYYY", "YYYY"]}
-                    isInvalid={!isValid}
-                    isLoading={loading}
-                    minDate={minDate}
-                    maxDate={maxDate}
-                    onChange={onChangeEnd}
-                    onClear={onChangeEnd}
-                    openToDate={dateRange?.endDate || maxDate}
-                    placeholder="to"
-                    selected={dateRange?.endDate}
-                    startDate={dateRange?.startDate}
-                />
-            )}
-        />
+        </div>
     );
 }

--- a/src/pages/LettersSearchPage/useDateFilter.js
+++ b/src/pages/LettersSearchPage/useDateFilter.js
@@ -37,7 +37,7 @@ export function useDateFilter() {
                         !== searchParams.get("dateMax"))
                 || !dateRange.startDate
                 || !dateRange.endDate)
-            && datesValid({ ...dateRange })
+            && datesValid(dateRange)
         ) {
             setSearchParams((prevParams) => {
                 // ensure other params don't get lost


### PR DESCRIPTION
## In this PR

- Per #54:
  - Date range errors (i.e. "from" date is after "to" date) will show an error and not just a red underline
  - Dates are no longer considered invalid if they are outside of the range of the data, though they remain un-selectable in the calendar view
- Fix bug with entity related letters view: when a date filter was _removed_, the removal was not reflected in the URL query params