### PR TITLE
Change date filter format from "MM/DD/YYYY" to "DD/MM/YYYY"

### DIFF
--- a/src/components/LetterDateFilter.jsx
+++ b/src/components/LetterDateFilter.jsx
@@ -33,7 +33,7 @@ export function LetterDateFilter({
                     <EuiDatePicker
                         aria-label="Start date"
                         endDate={dateRange?.endDate}
-                        dateFormat={["MM/DD/YYYY", "YYYY"]}
+                        dateFormat={["DD/MM/YYYY", "YYYY"]}
                         isInvalid={!isValid}
                         isLoading={loading}
                         minDate={minDate}
@@ -50,7 +50,7 @@ export function LetterDateFilter({
                     <EuiDatePicker
                         aria-label="End date"
                         endDate={dateRange?.endDate}
-                        dateFormat={["MM/DD/YYYY", "YYYY"]}
+                        dateFormat={["DD/MM/YYYY", "YYYY"]}
                         isInvalid={!isValid}
                         isLoading={loading}
                         minDate={minDate}


### PR DESCRIPTION
Allows user to enter the date as DD/MM/YYYY in the date filters in order to have a consistent experience of only interacting with European date formats on the site, per the following user story:
 <blockquote class="trello-card"><a href="https:&#x2F;&#x2F;trello.com&#x2F;c&#x2F;88n9RHEQ&#x2F;47-european-date-filters">european date filters</a></blockquote>


**Visual changes:**

**Before**
![Screenshot 2023-02-10 at 1 10 22 PM](https://user-images.githubusercontent.com/20568337/218180530-7d9cd95d-e67c-41c1-8964-48802b1028fb.png)


**After**
![Screenshot 2023-02-10 at 1 10 02 PM](https://user-images.githubusercontent.com/20568337/218179810-a44c5d59-2edf-4347-9881-59aea3802927.png)
