### PR TITLE
Make Entities search results sortable

### DIFF
--- a/src/components/EntitiesResults.jsx
+++ b/src/components/EntitiesResults.jsx
@@ -1,4 +1,5 @@
 import { Link } from "react-router-dom";
+import { SortableHeader } from "./SortableHeader";
 import "./EntitiesResults.css";
 
 /**
@@ -7,16 +8,28 @@ import "./EntitiesResults.css";
  * @param {object} props Props for React functional component
  * @param {object} props.data Data returned by ElasticSearch
  * @param {number} props.offset Offset of results for current page
+ * @param {Function} props.onSort Sort handler
+ * @param {object} props.sortState Current sort state
  * @returns Populated results list React component
  */
-function EntitiesResults({ data, offset }) {
+function EntitiesResults({
+    data, offset, onSort, sortState,
+}) {
+    const sortableColumns = ["entity", "type"];
     return (
         <table id="entities-results" className="search-results">
             <thead>
                 <tr>
                     <th aria-label="index">#</th>
-                    <th>Entity</th>
-                    <th>Type</th>
+                    {sortableColumns.map((column) => (
+                        <th key={column}>
+                            <SortableHeader
+                                name={column}
+                                onSort={onSort}
+                                sortState={sortState}
+                            />
+                        </th>
+                    ))}
                 </tr>
             </thead>
             <tbody>

--- a/src/pages/EntitiesSearchPage/EntitiesSearchPage.jsx
+++ b/src/pages/EntitiesSearchPage/EntitiesSearchPage.jsx
@@ -160,6 +160,9 @@ function EntitiesSearch() {
                             loading={loading}
                             onSearch={(value) => {
                                 setQuery(value);
+                                if (value == "") {
+                                    setSortState({ field: "entity", direction: 1 })
+                                } else { setSortState({ field: "relevance" }) }
                                 setSearchParams(
                                     stateToRoute({
                                         ...variables,
@@ -169,6 +172,7 @@ function EntitiesSearch() {
                                         page: {
                                             from: 0,
                                         },
+                                        sortBy: value == "" ? "" : "relevance"
                                     }),
                                 );
                             }}
@@ -219,6 +223,7 @@ function EntitiesSearch() {
                                 isLoading={loading}
                                 onClick={() => {
                                     // reset query and filters
+                                    setSortState({ field: "entity", direction: 1 })
                                     setQuery("");
                                     setSearchParams(
                                         stateToRoute({

--- a/src/pages/EntitiesSearchPage/EntitiesSearchPage.jsx
+++ b/src/pages/EntitiesSearchPage/EntitiesSearchPage.jsx
@@ -29,6 +29,9 @@ import { icon as EuiIconArrowRight } from "@elastic/eui/es/components/icon/asset
 import { icon as EuiIconCross } from "@elastic/eui/es/components/icon/assets/cross";
 import { icon as EuiIconSearch } from "@elastic/eui/es/components/icon/assets/search";
 import { icon as EuiIconQuestion } from "@elastic/eui/es/components/icon/assets/question_in_circle";
+import { icon as EuiIconSortable } from "@elastic/eui/es/components/icon/assets/sortable";
+import { icon as EuiIconSortUp } from "@elastic/eui/es/components/icon/assets/sort_up";
+import { icon as EuiIconSortDown } from "@elastic/eui/es/components/icon/assets/sort_down";
 import {
     analyzers,
     entitiesSearchConfig,
@@ -52,8 +55,11 @@ appendIconComponentCache({
     arrowLeft: EuiIconArrowLeft,
     arrowRight: EuiIconArrowRight,
     cross: EuiIconCross,
-    search: EuiIconSearch,
     questionInCircle: EuiIconQuestion,
+    search: EuiIconSearch,
+    sortable: EuiIconSortable,
+    sortUp: EuiIconSortUp,
+    sortDown: EuiIconSortDown,
 });
 
 /**
@@ -73,6 +79,34 @@ function EntitiesSearch() {
         config: entitiesSearchConfig,
         fields,
     });
+    const [sortState, setSortState] = useState(() => {
+        if (searchParams?.has("sort")) {
+            const [field, dir] = searchParams.get("sort").split("_");
+            const direction = dir === "asc" ? 1 : -1;
+            return { field, direction };
+        }
+        // default sort: short_display asc
+        return {
+            field: "entity",
+            direction: 1,
+        };
+    });
+    /**
+     * Curried event listener function to set the sort state to a given field.
+     *
+     * @param {string} field The name of the field to sort on.
+     * @returns {Function} The event listner function.
+     */
+    const onSort = (field) => () => {
+        if (sortState.field === field) {
+            setSortState((prevState) => ({
+                field,
+                direction: -1 * prevState.direction,
+            }));
+        } else {
+            setSortState({ field, direction: 1 });
+        }
+    };
 
     // Use React Router useSearchParams to translate to and from URL query params
     useEffect(() => {
@@ -81,6 +115,24 @@ function EntitiesSearch() {
             api.search();
         }
     }, [searchParams]);
+    useEffect(() => {
+        // handle sorting separately in order to only update in case of changes
+        if (sortState) {
+            const dir = sortState.direction === 1 ? "asc" : "desc";
+            const sortBy = `${sortState.field}_${dir}`;
+            if (!searchParams.has("sort") || searchParams.get("sort") !== sortBy) {
+                setSearchParams(
+                    stateToRoute({
+                        ...variables,
+                        query,
+                        sortBy,
+                        scope,
+                        operator,
+                    }),
+                );
+            }
+        }
+    }, [sortState]);
     useEffect(() => {
         if (operator && searchParams && (!searchParams.has("op") || searchParams.get("op") !== operator)) {
             setSearchParams(
@@ -194,6 +246,8 @@ function EntitiesSearch() {
                                 <EntitiesResults
                                     data={results}
                                     offset={variables?.page?.from}
+                                    onSort={onSort}
+                                    sortState={sortState}
                                 />
                                 <EuiFlexGroup justifyContent="spaceAround">
                                     <Pagination data={results} />

--- a/src/pages/EntitiesSearchPage/EntitiesSearchPage.jsx
+++ b/src/pages/EntitiesSearchPage/EntitiesSearchPage.jsx
@@ -118,8 +118,11 @@ function EntitiesSearch() {
     useEffect(() => {
         // handle sorting separately in order to only update in case of changes
         if (sortState) {
-            const dir = sortState.direction === 1 ? "asc" : "desc";
-            const sortBy = `${sortState.field}_${dir}`;
+            let sortBy = sortState.field;
+            if (sortState.direction) {
+                const dir = sortState.direction === 1 ? "asc" : "desc";
+                sortBy = `${sortState.field}_${dir}`;
+            }
             if (!searchParams.has("sort") || searchParams.get("sort") !== sortBy) {
                 setSearchParams(
                     stateToRoute({

--- a/src/pages/EntitiesSearchPage/entitiesSearchConfig.js
+++ b/src/pages/EntitiesSearchPage/entitiesSearchConfig.js
@@ -46,4 +46,28 @@ export const entitiesSearchConfig = {
             size: 100, // Show at most 100 facets (there won't be that many!)
         }),
     ],
+    sortOptions: [
+        { id: "relevance", label: "Relevance", field: "_score" },
+        {
+            id: "entity_asc",
+            label: "Entity (Ascending)",
+            field: { short_display: "asc" },
+            defaultOption: true,
+        },
+        {
+            id: "entity_desc",
+            label: "Entity (Descending)",
+            field: { short_display: "desc" },
+        },
+        {
+            id: "type_asc",
+            label: "Type (Ascending)",
+            field: { e_type: "asc" },
+        },
+        {
+            id: "type_desc",
+            label: "Type (Descending)",
+            field: { e_type: "desc" },
+        },
+    ],
 };

--- a/src/pages/LettersSearchPage/LettersSearchPage.jsx
+++ b/src/pages/LettersSearchPage/LettersSearchPage.jsx
@@ -127,8 +127,11 @@ function LettersSearch() {
     useEffect(() => {
         // handle sorting separately in order to only update in case of changes
         if (sortState) {
-            const dir = sortState.direction === 1 ? "asc" : "desc";
-            const sortBy = `${sortState.field}_${dir}`;
+            let sortBy = sortState.field;
+            if (sortState.direction) {
+                const dir = sortState.direction === 1 ? "asc" : "desc";
+                sortBy = `${sortState.field}_${dir}`;
+            }
             if (!searchParams.has("sort") || searchParams.get("sort") !== sortBy) {
                 setSearchParams(
                     stateToRoute({


### PR DESCRIPTION
Make Entities search results sortable by 'Entity' and 'Type' columns (default sort on 'Entity'), per the following user story:
<blockquote class="trello-card"><a href="https:&#x2F;&#x2F;trello.com&#x2F;c&#x2F;B64WjZAc&#x2F;49-sequencing">sequencing</a></blockquote>

**Visual changes:**

**Before**
![Screenshot 2023-02-13 at 4 16 53 PM](https://user-images.githubusercontent.com/20568337/218587933-f75d6e78-01d8-42ce-907a-4f1d9f74d4c7.png)

**After**
![Screenshot 2023-02-13 at 4 16 05 PM](https://user-images.githubusercontent.com/20568337/218588012-aa049f83-4ed6-4415-b40b-6e6eed9668c4.png)
