### PR TITLE
Add year range filter to Entities

### DIFF
--- a/src/common/searchRouting.js
+++ b/src/common/searchRouting.js
@@ -89,7 +89,7 @@ export function routeToState(route) {
                 "dateMin", // also handle date filters separately
                 "dateMax",
                 "yearMin",
-                "yearMax"
+                "yearMax",
             ].includes(key),
         )
         .forEach(([identifier, val]) => {

--- a/src/common/searchRouting.js
+++ b/src/common/searchRouting.js
@@ -28,6 +28,14 @@ export function stateToRoute(searchState) {
             routeState.dateMax = filter.dateMax
                 ? moment(filter.dateMax).format("YYYY-MM-DD")
                 : undefined;
+        } else if (filter.identifier === "start_year") {
+            routeState.yearMin = filter.yearMin
+                ? filter.yearMin
+                : undefined;
+        } else if (filter.identifier === "end_year") {
+            routeState.yearMax = filter.yearMax
+                ? filter.yearMax
+                : undefined;
         } else if (filter.value) {
             if (Object.hasOwn(routeState, filter.identifier)) {
                 routeState[filter.identifier].push(filter.value);
@@ -80,6 +88,8 @@ export function routeToState(route) {
                 "op",
                 "dateMin", // also handle date filters separately
                 "dateMax",
+                "yearMin",
+                "yearMax"
             ].includes(key),
         )
         .forEach(([identifier, val]) => {
@@ -108,6 +118,18 @@ export function routeToState(route) {
         searchState.filters.push({
             identifier: "end_date",
             dateMax: moment(route.get("dateMax")).toISOString(),
+        });
+    }
+    if (route.has("yearMin")) {
+        searchState.filters.push({
+            identifier: "start_year",
+            yearMin: route.get("yearMin"),
+        });
+    }
+    if (route.has("yearMax")) {
+        searchState.filters.push({
+            identifier: "end_year",
+            yearMax: route.get("yearMax"),
         });
     }
     return searchState;

--- a/src/common/useCustomSearchkitSDK.js
+++ b/src/common/useCustomSearchkitSDK.js
@@ -13,7 +13,6 @@ import { routeToState } from "./searchRouting";
  * @param {Array<string>} kwargs.analyzers List of input analyzer names
  * @param {object} kwargs.config Initial search config
  * @param {Array<object>} kwargs.fields List of Field objects ({ name, boost })
- * @param {string} kwargs.operator Search operator
  * @returns {object} Response in the form { results: SearchkitResponse; loading: boolean }
  */
 export const useCustomSearchkitSDK = ({
@@ -120,6 +119,6 @@ export const useCustomSearchkitSDK = ({
         loading,
         dateRange,
         dateRangeLoading,
-        yearRange
+        yearRange,
     };
 };

--- a/src/common/useCustomSearchkitSDK.js
+++ b/src/common/useCustomSearchkitSDK.js
@@ -26,6 +26,7 @@ export const useCustomSearchkitSDK = ({
     const [dateRange, setDateRange] = useState(null);
     const [dateRangeLoading, setDateRangeLoading] = useState(true);
     const [searchParams, _] = useSearchParams();
+    const [yearRange, setYearRange] = useState(null);
 
     if (config?.name === "letters") {
         // initial request to get global date range with no filters/query
@@ -52,6 +53,30 @@ export const useCustomSearchkitSDK = ({
                 setDateRangeLoading(false);
             }
             fetchDateData();
+        }, []); // (perform once, on page render)
+    }
+
+    if (config?.name === "entities") {
+        // initial request to get global year range with no filters/query
+        useEffect(() => {
+            // eslint-disable-next-line jsdoc/require-jsdoc
+            async function fetchYearData() {
+                const request = createInstance({
+                    ...config,
+                    query: buildQuery({ analyzers, fields }),
+                });
+                const response = await request.execute({
+                    facets: true,
+                    hits: { size: 0 },
+                });
+                // get min and max year facet values
+                const minYear = response?.facets?.find((f) => f.identifier === "min_year")
+                    ?.value || null;
+                const maxYear = response?.facets?.find((f) => f.identifier === "max_year")
+                    ?.value || null;
+                setYearRange({ minYear, maxYear });
+            }
+            fetchYearData();
         }, []); // (perform once, on page render)
     }
 
@@ -95,5 +120,6 @@ export const useCustomSearchkitSDK = ({
         loading,
         dateRange,
         dateRangeLoading,
+        yearRange
     };
 };

--- a/src/components/ValueFilter.jsx
+++ b/src/components/ValueFilter.jsx
@@ -22,16 +22,22 @@ function ValueFilter({ filter, loading }) {
         valueLabel = volumeLabels[filter.value];
     }
 
+    /**
+     * Function to be used inside of current search filters filter
+     *
+     * @param {object} f - filter object
+     * @returns {boolean} Boolean value to be used in filter function
+     */
     const filtersFilter = (f) => {
-      switch(f.identifier) {
-        case "start_year":
-          return !(f.yearMin === filter.value && f.identifier === filter.identifier)
-        case "end_year":
-          return !(f.identifier === filter.identifier && f.yearMax === filter.value)
-        default:
-          return !(f.value === filter.value && f.identifier === filter.identifier)
-      }
-    }
+        switch (f.identifier) {
+            case "start_year":
+                return !(f.yearMin === filter.value && f.identifier === filter.identifier);
+            case "end_year":
+                return !(f.identifier === filter.identifier && f.yearMax === filter.value);
+            default:
+                return !(f.value === filter.value && f.identifier === filter.identifier);
+        }
+    };
 
     return (
         <EuiFlexItem grow={false}>
@@ -42,8 +48,7 @@ function ValueFilter({ filter, loading }) {
                 onClick={() => {
                     const filters = api
                         .getFilters()
-                        .filter((f) => filtersFilter(f)
-                        );
+                        .filter((f) => filtersFilter(f));
                     setSearchParams(
                         stateToRoute({
                             ...variables,

--- a/src/components/ValueFilter.jsx
+++ b/src/components/ValueFilter.jsx
@@ -21,6 +21,18 @@ function ValueFilter({ filter, loading }) {
     ) {
         valueLabel = volumeLabels[filter.value];
     }
+
+    const filtersFilter = (f) => {
+      switch(f.identifier) {
+        case "start_year":
+          return !(f.yearMin === filter.value && f.identifier === filter.identifier)
+        case "end_year":
+          return !(f.identifier === filter.identifier && f.yearMax === filter.value)
+        default:
+          return !(f.value === filter.value && f.identifier === filter.identifier)
+      }
+    }
+
     return (
         <EuiFlexItem grow={false}>
             <EuiButton
@@ -30,9 +42,8 @@ function ValueFilter({ filter, loading }) {
                 onClick={() => {
                     const filters = api
                         .getFilters()
-                        .filter((f) => !(
-                            f.value === filter.value && f.identifier === filter.identifier
-                        ));
+                        .filter((f) => filtersFilter(f)
+                        );
                     setSearchParams(
                         stateToRoute({
                             ...variables,

--- a/src/components/YearRangeFacet.jsx
+++ b/src/components/YearRangeFacet.jsx
@@ -45,7 +45,7 @@ function YearRangeFacet({
                     value={[yearRange.startYear || "", yearRange.endYear || ""]}
                     onChange={onRangeChange}
                     fullWidth
-                    min={minYear}
+                    min={minYear || 1900}
                     max={maxYear}
                     showInput="inputWithPopover"
                     showLabels

--- a/src/components/YearRangeFacet.jsx
+++ b/src/components/YearRangeFacet.jsx
@@ -1,48 +1,61 @@
-import React, { useState } from 'react';
+import React from "react";
 import {
-  EuiDualRange,
-  EuiFormRow,
-  EuiTitle
-} from '@elastic/eui';
+    EuiDualRange,
+    EuiFormRow,
+    EuiTitle,
+} from "@elastic/eui";
 
+/**
+ * YearRange facet display component, adapted from @searchkit/elastic-ui but with the
+ * ability to use minimum and maximum year aggregations across the dataset.
+ *
+ * @param {object} props - React functional component props
+ * @param {number} props.minYear - Min year returned from API
+ * @param {number} props.maxYear - Max year returned from API
+ * @param {Function} props.setYearRange - Function to set year range state
+ * @param {object} props.yearRange - Current year range state
+ * @returns {React.Component} Year range React component
+ */
 function YearRangeFacet({
-  minYear, maxYear, setYearRange, yearRange
+    minYear, maxYear, setYearRange, yearRange,
 }) {
+    /**
+     * Handle change in start/end year of year filtering range
+     *
+     * @param {Array<number>} value - start and end years of year filtering range
+     */
+    const onRangeChange = (value) => {
+        setYearRange((prevState) => ({
+            ...prevState,
+            startYear: value[0],
+            endYear: value[1],
+        }));
+    };
 
-  const onRangeChange = (value) => {
-    // value is an array of [val1, val2]
-    setYearRange((prevState) => ({
-        ...prevState,
-        startYear: parseInt(value[0]),
-        endYear: parseInt(value[1])
-    }));
-  };
+    // Passing empty strings as the value allows the inputs to be blank,
+    // though the range handles will still be placed at the min/max positions
 
-
-  // Passing empty strings as the value allows the inputs to be blank,
-  // though the range handles will still be placed at the min/max positions
-
-  return (
-    <>
-      <EuiTitle size="xxs">
-        <h3>Years</h3>
-      </EuiTitle>
-      <EuiFormRow>
-        <EuiDualRange
-          value={[yearRange.startYear || "", yearRange.endYear || ""]}
-          onChange={onRangeChange}
-          fullWidth
-          min={minYear}
-          max={maxYear}
-          showInput={"inputWithPopover"}
-          showLabels
-          aria-label="Year filter input form"
-          prepend="From"
-          append="To"
-        />
-      </EuiFormRow>
-    </>
-  );
-};
+    return (
+        <>
+            <EuiTitle size="xxs">
+                <h3>Years</h3>
+            </EuiTitle>
+            <EuiFormRow>
+                <EuiDualRange
+                    value={[yearRange.startYear || "", yearRange.endYear || ""]}
+                    onChange={onRangeChange}
+                    fullWidth
+                    min={minYear}
+                    max={maxYear}
+                    showInput="inputWithPopover"
+                    showLabels
+                    aria-label="Year filter input form"
+                    prepend="From"
+                    append="To"
+                />
+            </EuiFormRow>
+        </>
+    );
+}
 
 export default YearRangeFacet;

--- a/src/components/YearRangeFacet.jsx
+++ b/src/components/YearRangeFacet.jsx
@@ -1,0 +1,48 @@
+import React, { useState } from 'react';
+import {
+  EuiDualRange,
+  EuiFormRow,
+  EuiTitle
+} from '@elastic/eui';
+
+function YearRangeFacet({
+  minYear, maxYear, setYearRange, yearRange
+}) {
+
+  const onRangeChange = (value) => {
+    // value is an array of [val1, val2]
+    setYearRange((prevState) => ({
+        ...prevState,
+        startYear: parseInt(value[0]),
+        endYear: parseInt(value[1])
+    }));
+  };
+
+
+  // Passing empty strings as the value allows the inputs to be blank,
+  // though the range handles will still be placed at the min/max positions
+
+  return (
+    <>
+      <EuiTitle size="xxs">
+        <h3>Years</h3>
+      </EuiTitle>
+      <EuiFormRow>
+        <EuiDualRange
+          value={[yearRange.startYear || "", yearRange.endYear || ""]}
+          onChange={onRangeChange}
+          fullWidth
+          min={minYear}
+          max={maxYear}
+          showInput={"inputWithPopover"}
+          showLabels
+          aria-label="Year filter input form"
+          prepend="From"
+          append="To"
+        />
+      </EuiFormRow>
+    </>
+  );
+};
+
+export default YearRangeFacet;

--- a/src/pages/EntitiesSearchPage/CustomYearRangeFacet.js
+++ b/src/pages/EntitiesSearchPage/CustomYearRangeFacet.js
@@ -1,0 +1,94 @@
+export class CustomYearRangeFacet {
+    /**
+     * A facet used to filter by year range in the dataset. Adapted from @searchkit/sdk, but
+     * modified to create separate filters for start and end year.
+     *
+     * @param {object} config Configuration options
+     */
+    constructor(config) {
+        this.config = config;
+        this.excludeOwnFilters = true;
+    }
+
+    /**
+     * Identifier, which must be unique to facet.
+     *
+     * @returns {string} Identifier
+     */
+    getIdentifier() {
+        return this.config.identifier;
+    }
+
+    /**
+     * Label used for display, if displayed.
+     *
+     * @returns {string} Label
+     */
+    getLabel() {
+        return this.config.label;
+    }
+
+    /**
+     * Generate ES range filter object from chosen years.
+     *
+     * @param {Array<object>} filters The filter from the search state.
+     * @returns {object} The resulting range filter.
+     */
+    getFilters(filters) {
+        const rangeFilter = {};
+        if (filters[0]?.yearMin) {
+            rangeFilter.gte = filters[0].yearMin;
+        } else if (filters[0]?.yearMax) {
+            rangeFilter.lte = filters[0].yearMax;
+        }
+        return { range: { [this.config.field]: rangeFilter } };
+    }
+
+    /**
+     * Force empty aggregation
+     *
+     * @returns {object} Empty object
+     */
+    // eslint-disable-next-line class-methods-use-this
+    getAggregation() {
+        return {};
+    }
+
+    /**
+     * Returns an object used for filter choice presentation.
+     *
+     * @param {object} filterSet The filter from the search state.
+     * @returns {object} Object used by appliedFilters for presentation.
+     */
+    getSelectedFilter(filterSet) {
+        return {
+            type: "YearRangeSelectedFilter",
+            id: `${this.getIdentifier()}_${
+                filterSet.yearMin || filterSet.yearMax
+            }`,
+            identifier: this.getIdentifier(),
+            label: this.getLabel(),
+            yearMin: filterSet.yearMin,
+            yearMax: filterSet.yearMax,
+            display: this.config.display || "CustomYearFacet",
+            value: filterSet.yearMin || filterSet.yearMax
+        };
+    }
+
+    /**
+     * transform ES response into an object that matches the Facet Schema type
+     *
+     * @returns {object} Facet Schema object
+     */
+    transformResponse() {
+        return {
+            identifier: this.getIdentifier(),
+            label: this.getLabel(),
+            type: "YearRangeFacet",
+            display: this.config.display || "CustomYearFacet",
+            entries: null,
+        };
+    }
+}
+
+export default CustomYearRangeFacet;

--- a/src/pages/EntitiesSearchPage/CustomYearRangeFacet.js
+++ b/src/pages/EntitiesSearchPage/CustomYearRangeFacet.js
@@ -71,7 +71,7 @@ export class CustomYearRangeFacet {
             yearMin: filterSet.yearMin,
             yearMax: filterSet.yearMax,
             display: this.config.display || "CustomYearFacet",
-            value: filterSet.yearMin || filterSet.yearMax
+            value: filterSet.yearMin || filterSet.yearMax,
         };
     }
 

--- a/src/pages/EntitiesSearchPage/EntitiesSearchPage.jsx
+++ b/src/pages/EntitiesSearchPage/EntitiesSearchPage.jsx
@@ -73,14 +73,14 @@ appendIconComponentCache({
 function EntitiesSearch() {
     const [searchParams, setSearchParams] = useSearchParams();
     const [query, setQuery] = useState(() => (searchParams.has("query") ? searchParams.get("query") : ""));
-    const [operator, setOperator] = useState(searchParams.has("op") ? searchParams.get("op") : "or");
+    const [operator, setOperator] = useState(
+        searchParams.has("op") ? searchParams.get("op") : "or",
+    );
     const [yearRangeState, setYearRangeState] = useYearFilter();
     const [scope, setScope] = useScope();
     const api = useSearchkit();
     const variables = useSearchkitVariables();
-    const {
-      results, loading, yearRange
-    } = useCustomSearchkitSDK({
+    const { results, loading, yearRange } = useCustomSearchkitSDK({
         analyzers,
         config: entitiesSearchConfig,
         fields,
@@ -129,7 +129,10 @@ function EntitiesSearch() {
                 const dir = sortState.direction === 1 ? "asc" : "desc";
                 sortBy = `${sortState.field}_${dir}`;
             }
-            if (!searchParams.has("sort") || searchParams.get("sort") !== sortBy) {
+            if (
+                !searchParams.has("sort")
+                || searchParams.get("sort") !== sortBy
+            ) {
                 setSearchParams(
                     stateToRoute({
                         ...variables,
@@ -143,7 +146,11 @@ function EntitiesSearch() {
         }
     }, [sortState]);
     useEffect(() => {
-        if (operator && searchParams && (!searchParams.has("op") || searchParams.get("op") !== operator)) {
+        if (
+            operator
+            && searchParams
+            && (!searchParams.has("op") || searchParams.get("op") !== operator)
+        ) {
             setSearchParams(
                 stateToRoute({
                     ...variables,
@@ -166,9 +173,14 @@ function EntitiesSearch() {
                             loading={loading}
                             onSearch={(value) => {
                                 setQuery(value);
-                                if (value == "") {
-                                    setSortState({ field: "entity", direction: 1 })
-                                } else { setSortState({ field: "relevance" }) }
+                                if (value === "") {
+                                    setSortState({
+                                        field: "entity",
+                                        direction: 1,
+                                    });
+                                } else {
+                                    setSortState({ field: "relevance" });
+                                }
                                 setSearchParams(
                                     stateToRoute({
                                         ...variables,
@@ -178,7 +190,7 @@ function EntitiesSearch() {
                                         page: {
                                             from: 0,
                                         },
-                                        sortBy: value == "" ? "" : "relevance"
+                                        sortBy: value === "" ? "" : "relevance",
                                     }),
                                 );
                             }}
@@ -202,18 +214,18 @@ function EntitiesSearch() {
                         <EuiHorizontalRule margin="m" />
                         <EuiSpacer size="l" />
 
-                        {results?.facets.filter(
-                            (facet) => facet.display
-                                && facet.display !== "CustomYearFacet",
+                        {results?.facets
+                            .filter(
+                                (facet) => facet.display
+                                    && facet.display !== "CustomYearFacet",
                             )
                             .map((facet) => (
-                              <ListFacet
-                                  key={facet.identifier}
-                                  facet={facet}
-                                  loading={loading}
-                              />
-                            ))
-                        }
+                                <ListFacet
+                                    key={facet.identifier}
+                                    facet={facet}
+                                    loading={loading}
+                                />
+                            ))}
                     </EuiPageSideBar>
                 </aside>
                 <EuiPageBody component="section">
@@ -245,11 +257,14 @@ function EntitiesSearch() {
                                 isLoading={loading}
                                 onClick={() => {
                                     // reset query and filters
-                                    setSortState({ field: "entity", direction: 1 })
+                                    setSortState({
+                                        field: "entity",
+                                        direction: 1,
+                                    });
                                     api.setQuery("");
                                     setYearRangeState({
-                                      endYear: "",
-                                      startYear: ""
+                                        endYear: "",
+                                        startYear: "",
                                     });
                                     setSearchParams(
                                         stateToRoute({

--- a/src/pages/EntitiesSearchPage/EntitiesSearchPage.jsx
+++ b/src/pages/EntitiesSearchPage/EntitiesSearchPage.jsx
@@ -210,9 +210,7 @@ function EntitiesSearch() {
                             yearRange={yearRangeState}
                         />
 
-                        <EuiSpacer size="l" />
-                        <EuiHorizontalRule margin="m" />
-                        <EuiSpacer size="l" />
+                        <EuiSpacer size="s" />
 
                         {results?.facets
                             .filter(

--- a/src/pages/EntitiesSearchPage/MinMaxYearFacet.js
+++ b/src/pages/EntitiesSearchPage/MinMaxYearFacet.js
@@ -45,7 +45,7 @@ export class MinMaxYearFacet {
         return {
             [this.getIdentifier()]: {
                 [this.getMinMax()]: {
-                    field: this.config.field
+                    field: this.config.field,
                 },
             },
         };
@@ -63,7 +63,7 @@ export class MinMaxYearFacet {
             label: this.getLabel(),
             type: "CustomFacet",
             display: this.config.display,
-            value: response.value
+            value: response.value,
         };
     }
 }

--- a/src/pages/EntitiesSearchPage/MinMaxYearFacet.js
+++ b/src/pages/EntitiesSearchPage/MinMaxYearFacet.js
@@ -1,0 +1,69 @@
+export class MinMaxYearFacet {
+    /**
+     * A facet used to aggregate the minimum or maximum year in the dataset.
+     *
+     * @param {object} config Configuration options
+     */
+    constructor(config) {
+        this.config = config;
+        this.excludeOwnFilters = true;
+    }
+
+    /**
+     * Identifier, which must be unique to facet if not configured.
+     *
+     * @returns {string} Identifier
+     */
+    getIdentifier() {
+        return this.config.identifier;
+    }
+
+    /**
+     * Label used for display, if displayed (it's not in our app).
+     *
+     * @returns {string} Label
+     */
+    getLabel() {
+        return this.config.label;
+    }
+
+    /**
+     * String "min" or "max" to determine which kind of aggregation this is
+     *
+     * @returns {string} The string "min" or "max"
+     */
+    getMinMax() {
+        return this.config.minMax;
+    }
+
+    /**
+     * The ElasticSearch aggregation query for the facet
+     *
+     * @returns {object} Aggregation query object
+     */
+    getAggregation() {
+        return {
+            [this.getIdentifier()]: {
+                [this.getMinMax()]: {
+                    field: this.config.field
+                },
+            },
+        };
+    }
+
+    /**
+     * transform ES response into an object that matches the Facet Schema type
+     *
+     * @param {object} response ElasticSearch response object
+     * @returns {object} Facet Schema object, plus value field
+     */
+    transformResponse(response) {
+        return {
+            identifier: this.getIdentifier(),
+            label: this.getLabel(),
+            type: "CustomFacet",
+            display: this.config.display,
+            value: response.value
+        };
+    }
+}

--- a/src/pages/EntitiesSearchPage/entitiesSearchConfig.js
+++ b/src/pages/EntitiesSearchPage/entitiesSearchConfig.js
@@ -1,5 +1,7 @@
 import { RefinementSelectFacet } from "@ecds/searchkit-sdk";
 import { buildQuery } from "../../common";
+import { CustomYearRangeFacet } from "./CustomYearRangeFacet";
+import { MinMaxYearFacet } from "./MinMaxYearFacet";
 
 // kewyord field names to search on
 export const fields = [
@@ -33,10 +35,30 @@ export const entitiesSearchConfig = {
     },
     index: import.meta.env.VITE_SEARCHKIT_ENTITIES_INDEX,
     hits: {
-        fields: ["id", "short_display", "e_type"],
+        fields: ["id", "short_display", "e_type", "years"],
     },
     query: buildQuery({ analyzers, fields }),
     facets: [
+        new CustomYearRangeFacet({
+            field: "years",
+            identifier: "start_year",
+            label: "Start year"
+        }),
+        new CustomYearRangeFacet({
+            field: "years",
+            identifier: "end_year",
+            label: "End year"
+        }),
+        new MinMaxYearFacet({
+            field: "years",
+            identifier: "min_year",
+            minMax: "min",
+        }),
+        new MinMaxYearFacet({
+            field: "years",
+            identifier: "max_year",
+            minMax: "max",
+        }),
         new RefinementSelectFacet({
             field: "e_type",
             identifier: "e_type",

--- a/src/pages/EntitiesSearchPage/entitiesSearchConfig.js
+++ b/src/pages/EntitiesSearchPage/entitiesSearchConfig.js
@@ -42,12 +42,12 @@ export const entitiesSearchConfig = {
         new CustomYearRangeFacet({
             field: "years",
             identifier: "start_year",
-            label: "Start year"
+            label: "Start year",
         }),
         new CustomYearRangeFacet({
             field: "years",
             identifier: "end_year",
-            label: "End year"
+            label: "End year",
         }),
         new MinMaxYearFacet({
             field: "years",

--- a/src/pages/EntitiesSearchPage/useYearFilter.js
+++ b/src/pages/EntitiesSearchPage/useYearFilter.js
@@ -28,17 +28,13 @@ export function useYearFilter() {
     useEffect(() => {
         if (
             (yearRange?.startYear || yearRange?.endYear)
-            && (
-              // only set new year range once all 4 digits of year are entered
-                (!yearRange.startYear || yearRange.startYear > 999)
-                && (!yearRange.endYear || yearRange.endYear > 999)
-              )
-            && (
-                (yearRange?.startYear !== searchParams.get("yearMin"))
-              || (yearRange?.endYear !== searchParams.get("yearMax"))
-              || !yearRange.startYear
-              || !yearRange.endYear
-            )
+            // only set new year range once all 4 digits of year are entered
+            && (!yearRange.startYear || yearRange.startYear > 999)
+            && (!yearRange.endYear || yearRange.endYear > 999)
+            && (yearRange?.startYear !== searchParams.get("yearMin")
+                || yearRange?.endYear !== searchParams.get("yearMax")
+                || !yearRange.startYear
+                || !yearRange.endYear)
             && datesValid(yearRange)
         ) {
             setSearchParams((prevParams) => {
@@ -60,7 +56,7 @@ export function useYearFilter() {
                     );
                 }
                 // add each back if selected
-                if (yearRange.startYear || yearRange.startYear == 0) {
+                if (yearRange.startYear || yearRange.startYear === 0) {
                     state.filters.push({
                         identifier: "start_year",
                         yearMin: yearRange.startYear,

--- a/src/pages/EntitiesSearchPage/useYearFilter.js
+++ b/src/pages/EntitiesSearchPage/useYearFilter.js
@@ -1,0 +1,97 @@
+import { useState, useEffect } from "react";
+import { useSearchParams } from "react-router-dom";
+import { datesValid, routeToState, stateToRoute } from "../../common";
+
+/**
+ * Hook to abstract year filter state management away from the Letters search page component.
+ * Interfaces with Searchkit API to valiyear, read, and write start/end year filters; handles
+ * search URL query params; and uses effects to ensure synchronization between frontend state
+ * and Searchkit search state.
+ *
+ * @returns {Array<object, Function>} An array containing the current year frontend state and
+ * the setState function for it.
+ */
+export function useYearFilter() {
+    const [searchParams, setSearchParams] = useSearchParams();
+
+    // if a filter already present on initialization, set initial state to that range
+    const [yearRange, setYearRange] = useState({
+        startYear: searchParams?.has("yearMin")
+            ? searchParams.get("yearMin")
+            : "",
+        endYear: searchParams?.has("yearMax")
+            ? searchParams.get("yearMax")
+            : "",
+    });
+
+    // update filters when range is changed (to a valid range)
+    useEffect(() => {
+        if (
+            (yearRange?.startYear || yearRange?.endYear)
+            && (
+              // only set new year range once all 4 digits of year are entered
+                (!yearRange.startYear || yearRange.startYear > 999)
+                && (!yearRange.endYear || yearRange.endYear > 999)
+              )
+            && (
+                (yearRange?.startYear !== searchParams.get("yearMin"))
+              || (yearRange?.endYear !== searchParams.get("yearMax"))
+              || !yearRange.startYear
+              || !yearRange.endYear
+            )
+            && datesValid(yearRange)
+        ) {
+            setSearchParams((prevParams) => {
+                // ensure other params don't get lost
+                const state = routeToState(prevParams);
+                let prevStart;
+                let prevEnd;
+                // remove start and end year from search params
+                if (prevParams.has("yearMin")) {
+                    prevStart = prevParams.get("yearMin");
+                    state.filters = state.filters.filter(
+                        (f) => f.identifier !== "start_year",
+                    );
+                }
+                if (prevParams.has("yearMax")) {
+                    prevEnd = prevParams.get("yearMax");
+                    state.filters = state.filters.filter(
+                        (f) => f.identifier !== "end_year",
+                    );
+                }
+                // add each back if selected
+                if (yearRange.startYear || yearRange.startYear == 0) {
+                    state.filters.push({
+                        identifier: "start_year",
+                        yearMin: yearRange.startYear,
+                    });
+                }
+                if (yearRange.endYear) {
+                    state.filters.push({
+                        identifier: "end_year",
+                        yearMax: yearRange.endYear,
+                    });
+                }
+                // reset page to 0 if year filter changed, to avoid empty/nonexistent page
+                let page = {};
+                if (
+                    yearRange?.startYear !== prevStart
+                    || yearRange?.endYear !== prevEnd
+                ) {
+                    page = {
+                        page: {
+                            size: 25,
+                            from: 0,
+                        },
+                    };
+                }
+                return stateToRoute({
+                    ...state,
+                    ...page,
+                });
+            });
+        }
+    }, [yearRange]);
+
+    return [yearRange, setYearRange];
+}


### PR DESCRIPTION
This PR adds a UI component to filter by year range on the Entities Search Page. 

A few points to note:
* opted NOT to initialize with a default range (such as the min/max of all entities), as this filters out all entities with `null` year values in initial result list - but the min/max range of the _slider_ is based on min/max of all entities
* the range is technically 0 - 1988, as there are some entities with a year of `0` - this is why the slider shows such a narrow section for a range in, say, the 1900s

Related Trello card:
<blockquote class="trello-card"><a href="https:&#x2F;&#x2F;trello.com&#x2F;c&#x2F;S4UGc3aC&#x2F;52-date-component">Date Component</a></blockquote>

**Visual changes**


![Screenshot 2023-03-07 at 9 44 49 PM](https://user-images.githubusercontent.com/20568337/223618540-0b7758a5-f0f3-4c87-9f4a-e46b529ba345.png)
