### PR TITLE
Add "Save Search" button

### DIFF
--- a/src/common/search.css
+++ b/src/common/search.css
@@ -117,3 +117,6 @@ a.to-record:hover::before,
 a.to-record:focus::before {
     background-color: var(--primary-transparent);
 }
+.save-search {
+  margin-left: 5px;
+}

--- a/src/components/SaveSearchButton.jsx
+++ b/src/components/SaveSearchButton.jsx
@@ -1,0 +1,57 @@
+import { useState } from "react";
+import { EuiButton, EuiToolTip } from "@elastic/eui";
+
+/**
+ * Button to allow user to copy current URL to clipboard
+ *
+ * @returns React component
+ */
+function SaveSearchButton() {
+    const [disableSaveSearch, setDisableSaveSearch] = useState(false);
+
+    /**
+     * Disable button, copy current URL to clipboard, and re-enable button
+     */
+    const saveSearch = () => {
+        setDisableSaveSearch(true);
+        navigator.clipboard.writeText(window.location.href);
+        setTimeout(() => setDisableSaveSearch(false), 1500);
+    };
+
+    /**
+     * Render Save Search button
+     *
+     * @returns React component
+     */
+    const button = () => (
+        <EuiButton
+            color="text"
+            className="save-search"
+            disabled={disableSaveSearch}
+            onClick={saveSearch}
+        >
+            {disableSaveSearch ? "Copied!" : "Save Search"}
+        </EuiButton>
+    );
+
+    //  only rendering the tooltip when the button is not disabled is a
+    //  workaround to prevent the tooltip from getting stuck when the button
+    //  is disabled
+
+    return (
+        disableSaveSearch
+            ? button()
+            : (
+                <EuiToolTip
+                    className="tooltip"
+                    content="Copy current search URL to clipboard"
+                    position="top"
+                >
+                    {button()}
+                </EuiToolTip>
+            )
+
+    );
+}
+
+export default SaveSearchButton;

--- a/src/pages/EntitiesSearchPage/EntitiesSearchPage.jsx
+++ b/src/pages/EntitiesSearchPage/EntitiesSearchPage.jsx
@@ -19,7 +19,6 @@ import {
     EuiPageSideBar,
     EuiSpacer,
     EuiTitle,
-    EuiToolTip,
     EuiHorizontalRule,
     EuiFlexGroup,
     EuiButton,
@@ -42,6 +41,7 @@ import {
 } from "./entitiesSearchConfig";
 import EntitiesResults from "../../components/EntitiesResults";
 import ListFacet from "../../components/ListFacet";
+import SaveSearchButton from "../../components/SaveSearchButton";
 import { SearchControls } from "../../components/SearchControls";
 import YearRangeFacet from "../../components/YearRangeFacet";
 import {
@@ -77,7 +77,6 @@ function EntitiesSearch() {
     const [operator, setOperator] = useState(
         searchParams.has("op") ? searchParams.get("op") : "or",
     );
-    const [disableSaveSearch, setDisableSaveSearch] = useState(false);
     const [yearRangeState, setYearRangeState] = useYearFilter();
     const [scope, setScope] = useScope();
     const api = useSearchkit();
@@ -165,24 +164,6 @@ function EntitiesSearch() {
             );
         }
     }, [operator]);
-
-    const saveSearch = () => {
-      setDisableSaveSearch(true);
-      navigator.clipboard.writeText(location.href);
-      setTimeout(() => setDisableSaveSearch(false), 1500);
-    };
-
-    const saveSearchButton = () => (
-      <EuiButton
-          color="text"
-          className="save-search"
-          disabled={disableSaveSearch}
-          isLoading={loading}
-          onClick={() => saveSearch()}
-      >
-          {disableSaveSearch ? "Copied!" : "Save Search"}
-      </EuiButton>
-    );
 
     return (
         <main className="search-page">
@@ -294,17 +275,7 @@ function EntitiesSearch() {
                             >
                                 Reset Search
                             </EuiButton>
-
-                            { disableSaveSearch
-                              ? saveSearchButton()
-                              : <EuiToolTip
-                                  className="tooltip"
-                                  content="Copy search parameter URL to clipboard"
-                                  position="top"
-                                >
-                                  {saveSearchButton()}
-                                </EuiToolTip>
-                            }
+                            <SaveSearchButton />
 
                         </EuiPageHeaderSection>
                     </EuiPageHeader>

--- a/src/pages/EntitiesSearchPage/EntitiesSearchPage.jsx
+++ b/src/pages/EntitiesSearchPage/EntitiesSearchPage.jsx
@@ -19,6 +19,7 @@ import {
     EuiPageSideBar,
     EuiSpacer,
     EuiTitle,
+    EuiToolTip,
     EuiHorizontalRule,
     EuiFlexGroup,
     EuiButton,
@@ -76,6 +77,7 @@ function EntitiesSearch() {
     const [operator, setOperator] = useState(
         searchParams.has("op") ? searchParams.get("op") : "or",
     );
+    const [disableSaveSearch, setDisableSaveSearch] = useState(false);
     const [yearRangeState, setYearRangeState] = useYearFilter();
     const [scope, setScope] = useScope();
     const api = useSearchkit();
@@ -163,6 +165,24 @@ function EntitiesSearch() {
             );
         }
     }, [operator]);
+
+    const saveSearch = () => {
+      setDisableSaveSearch(true);
+      navigator.clipboard.writeText(location.href);
+      setTimeout(() => setDisableSaveSearch(false), 1500);
+    };
+
+    const saveSearchButton = () => (
+      <EuiButton
+          color="text"
+          className="save-search"
+          disabled={disableSaveSearch}
+          isLoading={loading}
+          onClick={() => saveSearch()}
+      >
+          {disableSaveSearch ? "Copied!" : "Save Search"}
+      </EuiButton>
+    );
 
     return (
         <main className="search-page">
@@ -274,6 +294,18 @@ function EntitiesSearch() {
                             >
                                 Reset Search
                             </EuiButton>
+
+                            { disableSaveSearch
+                              ? saveSearchButton()
+                              : <EuiToolTip
+                                  className="tooltip"
+                                  content="Copy search parameter URL to clipboard"
+                                  position="top"
+                                >
+                                  {saveSearchButton()}
+                                </EuiToolTip>
+                            }
+
                         </EuiPageHeaderSection>
                     </EuiPageHeader>
                     <EuiPageContent>

--- a/src/pages/LettersSearchPage/LettersSearchPage.jsx
+++ b/src/pages/LettersSearchPage/LettersSearchPage.jsx
@@ -44,6 +44,7 @@ import ListFacet from "../../components/ListFacet";
 import ValueFilter from "../../components/ValueFilter";
 import DateRangeFacet from "../../components/DateRangeFacet";
 import "../../common/search.css";
+import SaveSearchButton from "../../components/SaveSearchButton";
 import { SearchControls } from "../../components/SearchControls";
 import {
     routeToState,
@@ -261,6 +262,7 @@ function LettersSearch() {
                             >
                                 Reset Search
                             </EuiButton>
+                            <SaveSearchButton />
                         </EuiPageHeaderSection>
                     </EuiPageHeader>
                     <EuiPageContent>


### PR DESCRIPTION
This PR adds a button to the Entities Search page which does the following:
- Copies current URL (containing search params) to user's clipboard
- Displays tooltip text on hover to let the user know something will be copied to their clipboard (in case they have something else currently copied that they don't want to lose)
- Disables and displays a message ("Copied") for 1.5 seconds after button click to let the user know something has happened

Related Trello card:
<blockquote class="trello-card"><a href="https:&#x2F;&#x2F;trello.com&#x2F;c&#x2F;ekaase8s&#x2F;48-save-search-button">save search button</a></blockquote>

**Visual changes:**
_On hover_
![Screenshot 2023-03-10 at 2 26 18 PM](https://user-images.githubusercontent.com/20568337/224422731-9ef602d9-745f-4bda-985f-0e8b383686f1.png)

_After click_
![Screenshot 2023-03-10 at 2 27 11 PM](https://user-images.githubusercontent.com/20568337/224422787-d7eee233-a64e-46d3-87e2-853603813476.png)
