### PR TITLE
Remove calendar picker 'year' dropdown

### DIFF
--- a/src/components/LetterDateFilter.jsx
+++ b/src/components/LetterDateFilter.jsx
@@ -35,6 +35,7 @@ export function LetterDateFilter({
                 startDateControl={
                     <EuiDatePicker
                         aria-label="Start date"
+                        calendarClassName="letter-date-filter"
                         endDate={dateRange?.endDate}
                         dateFormat={["DD/MM/YYYY", "YYYY"]}
                         isInvalid={!isValid}
@@ -52,6 +53,7 @@ export function LetterDateFilter({
                 endDateControl={
                     <EuiDatePicker
                         aria-label="End date"
+                        calendarClassName="letter-date-filter"
                         endDate={dateRange?.endDate}
                         dateFormat={["DD/MM/YYYY", "YYYY"]}
                         isInvalid={!isValid}

--- a/src/pages/LetterPage/LetterPage.css
+++ b/src/pages/LetterPage/LetterPage.css
@@ -22,3 +22,7 @@ dl.letter-mentions dt:not(:first-of-type),
 dl.letter-mentions dt + dd:not(:first-of-type) {
     margin-top: 0.5rem;
 }
+
+.letter-date-filter .react-datepicker__year-dropdown-container {
+    display: none;
+}


### PR DESCRIPTION
This PR removes the calendar dropdown for the Letters Search date filter 

Related Trello card:
<blockquote class="trello-card"><a href="https:&#x2F;&#x2F;trello.com&#x2F;c&#x2F;q64Gz7Od&#x2F;65-remove-calendar-picker-year-dropdown-with-css">Remove calendar picker &quot;year&quot; dropdown with CSS</a></blockquote>

## BEFORE
![Screenshot 2023-03-20 at 4 17 14 PM](https://user-images.githubusercontent.com/20568337/226468110-64886c10-5671-439d-aa36-7322dfe1e369.png)


## AFTER

<img width="364" alt="Screenshot 2023-03-21 at 9 26 57 AM" src="https://user-images.githubusercontent.com/20568337/226729314-6b96c794-c632-4b8a-be72-3e069703a095.png">
