### PR TITLE
Update 'from' search param on variable change

### DIFF
--- a/src/pages/EntitiesSearchPage/EntitiesSearchPage.jsx
+++ b/src/pages/EntitiesSearchPage/EntitiesSearchPage.jsx
@@ -168,6 +168,18 @@ function EntitiesSearch() {
             );
         }
     }, [operator]);
+    useEffect(() => {
+        setSearchParams(
+            stateToRoute({
+                ...variables,
+                scope,
+                operator,
+                page: {
+                    from: variables.page.from,
+                },
+            }),
+        );
+    }, [variables?.page?.from]);
 
     return (
         <main className="search-page">

--- a/src/pages/LettersSearchPage/LettersSearchPage.jsx
+++ b/src/pages/LettersSearchPage/LettersSearchPage.jsx
@@ -170,6 +170,18 @@ function LettersSearch() {
             );
         }
     }, [operator]);
+    useEffect(() => {
+        setSearchParams(
+            stateToRoute({
+                ...variables,
+                scope,
+                operator,
+                page: {
+                    from: variables.page.from,
+                },
+            }),
+        );
+    }, [variables?.page?.from]);
 
     return (
         <main className="search-page">


### PR DESCRIPTION
Fixes #63 

Add listener to update search params when `from` page variable changes (seems this was not always happening when `variables.page.from` changed to zero, i.e. selecting page 1 of results)