### PR TITLE
BUG FIX - Prevent sortState listener from firing after search reset

### DIFF
--- a/src/pages/EntitiesSearchPage/EntitiesSearchPage.jsx
+++ b/src/pages/EntitiesSearchPage/EntitiesSearchPage.jsx
@@ -285,10 +285,7 @@ function EntitiesSearch() {
                                 isLoading={loading}
                                 onClick={() => {
                                     // reset query and filters
-                                    setSortState({
-                                        field: "entity",
-                                        direction: 1,
-                                    });
+
                                     api.setQuery("");
                                     setYearRangeState({
                                         endYear: "",
@@ -298,6 +295,10 @@ function EntitiesSearch() {
                                         stateToRoute({
                                             filters: [],
                                             query: "",
+                                            sort: {
+                                                field: "entity",
+                                                direction: 1,
+                                            },
                                         }),
                                     );
                                 }}


### PR DESCRIPTION
Fixes #66 

Clicking on the 'Reset Search' button was changing `sortState`, which in turn would cause the `sortState` `useEffect` hook to fire and repopulate the search params (which had just been cleared). This PR updates the sort param via a call to `stateToRoute` rather than `setSortState`, which prevents the `sortState` `useEffect` hook from firing.