### PR TITLE
Fix browser "back" button issue

### DIFF
--- a/src/pages/EntitiesSearchPage/EntitiesSearchPage.jsx
+++ b/src/pages/EntitiesSearchPage/EntitiesSearchPage.jsx
@@ -130,7 +130,8 @@ function EntitiesSearch() {
         // handle sorting separately in order to only update in case of changes
         if (sortState) {
             let sortBy = sortState.field;
-            if (sortState.direction) {
+            // relevance does not use direction
+            if (sortState.direction && sortBy !== "relevance") {
                 const dir = sortState.direction === 1 ? "asc" : "desc";
                 sortBy = `${sortState.field}_${dir}`;
             }
@@ -159,6 +160,7 @@ function EntitiesSearch() {
             setSearchParams(
                 stateToRoute({
                     ...variables,
+                    query,
                     scope,
                     operator,
                     page: {
@@ -172,6 +174,7 @@ function EntitiesSearch() {
         setSearchParams(
             stateToRoute({
                 ...variables,
+                query,
                 scope,
                 operator,
                 page: {

--- a/src/pages/LettersSearchPage/LettersSearchPage.jsx
+++ b/src/pages/LettersSearchPage/LettersSearchPage.jsx
@@ -132,7 +132,8 @@ function LettersSearch() {
         // handle sorting separately in order to only update in case of changes
         if (sortState) {
             let sortBy = sortState.field;
-            if (sortState.direction) {
+            // relevance does not use direction
+            if (sortState.direction && sortBy !== "relevance") {
                 const dir = sortState.direction === 1 ? "asc" : "desc";
                 sortBy = `${sortState.field}_${dir}`;
             }
@@ -161,6 +162,7 @@ function LettersSearch() {
             setSearchParams(
                 stateToRoute({
                     ...variables,
+                    query,
                     scope,
                     operator,
                     page: {
@@ -174,6 +176,7 @@ function LettersSearch() {
         setSearchParams(
             stateToRoute({
                 ...variables,
+                query,
                 scope,
                 operator,
                 page: {


### PR DESCRIPTION
## In this PR

In order to fix the browser "back" button blanking searches:
- Include `query` state in all `useEffect` calls, fix `relevance` sort directionality issue

There still seems to be some weirdness—I think the useEffects are getting called more than they should be—but at least the browser back button is now working consistently on my local machine. I want to see if it will work once deployed!