### PR TITLE
Allow long facet lists to be searched by text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
                 "@elastic/eui": "^42.1.0",
                 "@searchkit/client": "^3.0.0",
                 "@searchkit/schema": "^3.0.0",
+                "fold-to-ascii": "^5.0.1",
                 "moment": "^2.29.4",
                 "react": "^16.14.0",
                 "react-dom": "^16.14.0",
@@ -3251,6 +3252,14 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/fold-to-ascii": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/fold-to-ascii/-/fold-to-ascii-5.0.1.tgz",
+            "integrity": "sha512-VdMFm+u7pSzUWj0IDOniuHekp4lbMOtwKi6EsVx03DGVQaNI+77kxotj8hYaMmNkpym7wwv6c1woY4OZXYdqfg==",
+            "engines": {
+                "node": ">= 6.3.1"
             }
         },
         "node_modules/fs.realpath": {
@@ -9338,6 +9347,11 @@
             "requires": {
                 "tslib": "^2.0.3"
             }
+        },
+        "fold-to-ascii": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/fold-to-ascii/-/fold-to-ascii-5.0.1.tgz",
+            "integrity": "sha512-VdMFm+u7pSzUWj0IDOniuHekp4lbMOtwKi6EsVx03DGVQaNI+77kxotj8hYaMmNkpym7wwv6c1woY4OZXYdqfg=="
         },
         "fs.realpath": {
             "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
         "@elastic/eui": "^42.1.0",
         "@searchkit/client": "^3.0.0",
         "@searchkit/schema": "^3.0.0",
+        "fold-to-ascii": "^5.0.1",
         "moment": "^2.29.4",
         "react": "^16.14.0",
         "react-dom": "^16.14.0",

--- a/src/components/AccordionFacet.jsx
+++ b/src/components/AccordionFacet.jsx
@@ -29,6 +29,7 @@ function AccordionFacet({ facet, label }) {
                         displayTitle={false}
                         facet={facet}
                         loading={false}
+                        textSearchable
                     />
                 </EuiPanel>
             </EuiAccordion>

--- a/src/components/ListFacet.jsx
+++ b/src/components/ListFacet.jsx
@@ -1,12 +1,15 @@
-import { Fragment } from "react";
+import { Fragment, useState } from "react";
 import {
     EuiFacetButton,
     EuiFacetGroup,
+    EuiFieldText,
+    EuiSpacer,
     EuiTitle,
     EuiToolTip,
 } from "@elastic/eui";
 import { useSearchkit, useSearchkitVariables } from "@searchkit/client";
 import { useSearchParams } from "react-router-dom";
+import ASCIIFolder from "fold-to-ascii";
 import { entityTypes, stateToRoute, volumeLabels } from "../common";
 import "./ListFacet.css";
 
@@ -19,81 +22,95 @@ import "./ListFacet.css";
  * @param {boolean} props.displayTitle Indicate if title should be displayed
  * @param {object} props.facet The facet to render as a list of options
  * @param {boolean} props.loading Boolean indicating whether or not results are loading
+ * @param {boolean} props.textSearchable Indicate if text search box should be displayed
  * @returns {Fragment|null} ListFacet component set
  */
-function ListFacet({ displayTitle, facet, loading }) {
+function ListFacet({ displayTitle, facet, loading, textSearchable }) {
     const api = useSearchkit();
     const variables = useSearchkitVariables();
     const [_, setSearchParams] = useSearchParams();
-    const entries = facet?.entries?.map((entry) => {
-        let label = entry.label.toString().trim().replaceAll("_", " ");
-        // special handling for volume labels
-        if (
-            label &&
-            facet.identifier === "volume" &&
-            Object.keys(volumeLabels).includes(label)
-        ) {
-            label = volumeLabels[label];
-        }
-        // add tooltip for entity type facets
-        const ToolTipComponent =
-            facet.identifier === "e_type"
-                ? ({ children }) => (
-                      <EuiToolTip
-                          className="tooltip"
-                          content={entityTypes[entry.label] || entry.label}
-                      >
-                          {children}
-                      </EuiToolTip>
-                  ) // eslint-disable-next-line react/jsx-no-useless-fragment
-                : ({ children }) => <>{children}</>;
-        const filter = {
-            identifier: facet.identifier,
-            value: entry.label,
-        };
-        const isSelected = api.isFilterSelected(filter);
+    const [textFilter, setTextFilter] = useState("");
+    const entries = facet?.entries
+        // filter using any entered text
+        ?.filter(
+            (entry) =>
+                !textFilter ||
+                // fold Unicode to ASCII for quick searching
+                ASCIIFolder.foldMaintaining(
+                    entry.label.toString().toLowerCase(),
+                ).includes(
+                    ASCIIFolder.foldMaintaining(textFilter.toLowerCase()),
+                ),
+        )
+        .map((entry) => {
+            let label = entry.label.toString().trim().replaceAll("_", " ");
+            // special handling for volume labels
+            if (
+                label &&
+                facet.identifier === "volume" &&
+                Object.keys(volumeLabels).includes(label)
+            ) {
+                label = volumeLabels[label];
+            }
+            // add tooltip for entity type facets
+            const ToolTipComponent =
+                facet.identifier === "e_type"
+                    ? ({ children }) => (
+                          <EuiToolTip
+                              className="tooltip"
+                              content={entityTypes[entry.label] || entry.label}
+                          >
+                              {children}
+                          </EuiToolTip>
+                      ) // eslint-disable-next-line react/jsx-no-useless-fragment
+                    : ({ children }) => <>{children}</>;
+            const filter = {
+                identifier: facet.identifier,
+                value: entry.label,
+            };
+            const isSelected = api.isFilterSelected(filter);
 
-        return (
-            label && (
-                <EuiFacetButton
-                    className="facet-button"
-                    key={entry.label}
-                    quantity={entry.count}
-                    isSelected={isSelected}
-                    isLoading={loading}
-                    onClick={() => {
-                        let { filters } = variables;
-                        if (isSelected) {
-                            // remove on cilck
-                            filters = filters.filter(
-                                (f) =>
-                                    !(
-                                        f.identifier === facet.identifier &&
-                                        f.value === entry.label
-                                    ),
+            return (
+                label && (
+                    <EuiFacetButton
+                        className="facet-button"
+                        key={entry.label}
+                        quantity={entry.count}
+                        isSelected={isSelected}
+                        isLoading={loading}
+                        onClick={() => {
+                            let { filters } = variables;
+                            if (isSelected) {
+                                // remove on cilck
+                                filters = filters.filter(
+                                    (f) =>
+                                        !(
+                                            f.identifier === facet.identifier &&
+                                            f.value === entry.label
+                                        ),
+                                );
+                            } else {
+                                // add on click
+                                filters.push(filter);
+                            }
+                            setSearchParams(
+                                stateToRoute({
+                                    ...variables,
+                                    filters,
+                                    page: {
+                                        from: 0,
+                                    },
+                                }),
                             );
-                        } else {
-                            // add on click
-                            filters.push(filter);
-                        }
-                        setSearchParams(
-                            stateToRoute({
-                                ...variables,
-                                filters,
-                                page: {
-                                    from: 0,
-                                },
-                            }),
-                        );
-                    }}
-                >
-                    <ToolTipComponent>
-                        <span className="capital-label">{label}</span>
-                    </ToolTipComponent>
-                </EuiFacetButton>
-            )
-        );
-    });
+                        }}
+                    >
+                        <ToolTipComponent>
+                            <span className="capital-label">{label}</span>
+                        </ToolTipComponent>
+                    </EuiFacetButton>
+                )
+            );
+        });
 
     if (!facet) {
         return null;
@@ -105,6 +122,17 @@ function ListFacet({ displayTitle, facet, loading }) {
                 <EuiTitle size="xxs">
                     <h3>{facet.label}</h3>
                 </EuiTitle>
+            )}
+            {textSearchable && (
+                <>
+                    <EuiFieldText
+                        compressed
+                        placeholder="Type here to filter options"
+                        value={textFilter}
+                        onChange={(e) => setTextFilter(e.target.value)}
+                    />
+                    <EuiSpacer size="xs" />
+                </>
             )}
             <EuiFacetGroup className="facet-group">{entries}</EuiFacetGroup>
         </div>

--- a/src/pages/LettersSearchPage/LettersSearchPage.jsx
+++ b/src/pages/LettersSearchPage/LettersSearchPage.jsx
@@ -236,6 +236,9 @@ function LettersSearch() {
                                         data={results}
                                         facet={facet}
                                         loading={loading}
+                                        textSearchable={
+                                            facet.identifier === "repository"
+                                        }
                                     />
                                     <EuiSpacer size="l" />
                                 </div>


### PR DESCRIPTION
## In this PR

- Add optional prop `textSearchable` to `ListFacet` component, which, when enabled, adds a text box to filter the facet list by string
- Apply lowercase and Unicode folding to both the facet item labels and the entered text
- Set `textSearchable` true on the repositories facet list, as well as all string-type conditional facets

## Notes

I recommend hiding whitespace changes in the github diff viewer to read the changes more easily.