### PR TITLE
Bug fixes

### DIFF
--- a/src/common/searchRouting.js
+++ b/src/common/searchRouting.js
@@ -22,11 +22,11 @@ export function stateToRoute(searchState) {
         // date filter is formatted differently
         if (filter.identifier === "start_date") {
             routeState.dateMin = filter.dateMin
-                ? moment(filter.dateMin).format("YYYY-MM-DD")
+                ? moment.utc(filter.dateMin).format("YYYY-MM-DD")
                 : undefined;
         } else if (filter.identifier === "end_date") {
             routeState.dateMax = filter.dateMax
-                ? moment(filter.dateMax).format("YYYY-MM-DD")
+                ? moment.utc(filter.dateMax).format("YYYY-MM-DD")
                 : undefined;
         } else if (filter.identifier === "start_year") {
             routeState.yearMin = filter.yearMin ? filter.yearMin : undefined;
@@ -108,13 +108,13 @@ export function routeToState(route) {
     if (route.has("dateMin")) {
         searchState.filters.push({
             identifier: "start_date",
-            dateMin: moment(route.get("dateMin")).toISOString(),
+            dateMin: moment.utc(route.get("dateMin")).toISOString(),
         });
     }
     if (route.has("dateMax")) {
         searchState.filters.push({
             identifier: "end_date",
-            dateMax: moment(route.get("dateMax")).toISOString(),
+            dateMax: moment.utc(route.get("dateMax")).toISOString(),
         });
     }
     if (route.has("yearMin")) {

--- a/src/common/searchRouting.js
+++ b/src/common/searchRouting.js
@@ -148,3 +148,19 @@ export function isDefault(state) {
         state.page?.from === 0
     );
 }
+
+/**
+ * Convert a sort state to a sortBy string to use in URL routing.
+ *
+ * @param {object} sortState The sort state to convert
+ * @returns {string} String representation of the sort for URL routing
+ */
+export function getSortByFromState(sortState) {
+    let sortBy = sortState?.field;
+    // relevance does not use direction
+    if (sortState.direction && sortBy !== "relevance") {
+        const dir = sortState.direction === 1 ? "asc" : "desc";
+        sortBy = `${sortState.field}_${dir}`;
+    }
+    return sortBy;
+}

--- a/src/common/useCustomSearchkitSDK.js
+++ b/src/common/useCustomSearchkitSDK.js
@@ -41,11 +41,11 @@ export const useCustomSearchkitSDK = ({ config, analyzers, fields }) => {
                 const min =
                     response?.facets?.find((f) => f.identifier === "min_date")
                         ?.value || null;
-                const minDate = min ? moment(min) : null;
+                const minDate = min ? moment.utc(min) : null;
                 const max =
                     response?.facets?.find((f) => f.identifier === "max_date")
                         ?.value || null;
-                const maxDate = max ? moment(max) : null;
+                const maxDate = max ? moment.utc(max) : null;
                 setDateRange({ minDate, maxDate });
                 setDateRangeLoading(false);
             }

--- a/src/components/EntityRelatedLetters.jsx
+++ b/src/components/EntityRelatedLetters.jsx
@@ -25,10 +25,10 @@ export function EntityRelatedLetters({ title, type, uri }) {
     // get initial date range and filter states from search params, if possible
     const [dateRange, setDateRange] = useState({
         startDate: searchParams?.get(`${type}_startDate`)
-            ? moment(searchParams?.get(`${type}_startDate`))
+            ? moment.utc(searchParams?.get(`${type}_startDate`))
             : null,
         endDate: searchParams?.get(`${type}_endDate`)
-            ? moment(searchParams?.get(`${type}_endDate`))
+            ? moment.utc(searchParams?.get(`${type}_endDate`))
             : null,
     });
     const [filterState, setFilterState] = useState(
@@ -69,10 +69,10 @@ export function EntityRelatedLetters({ title, type, uri }) {
         const params = {
             page: filterState?.page ? filterState.page + 1 : 1,
             startDate: filterState?.startDate
-                ? moment(filterState.startDate).format(dateFormat)
+                ? moment.utc(filterState.startDate).format(dateFormat)
                 : undefined,
             endDate: filterState?.endDate
-                ? moment(filterState.endDate).format(dateFormat)
+                ? moment.utc(filterState.endDate).format(dateFormat)
                 : undefined,
         };
         // remove (and keep track of) any undefined key/value pairs
@@ -135,8 +135,8 @@ export function EntityRelatedLetters({ title, type, uri }) {
                 </EuiTitle>
                 {data && (
                     <LetterDateFilter
-                        minDate={moment(data.min_date)}
-                        maxDate={moment(data.max_date)}
+                        minDate={moment.utc(data.min_date)}
+                        maxDate={moment.utc(data.max_date)}
                         isValid={datesValid(dateRange)}
                         loading={loading}
                         dateRange={dateRange}

--- a/src/pages/EntitiesSearchPage/EntitiesSearchPage.jsx
+++ b/src/pages/EntitiesSearchPage/EntitiesSearchPage.jsx
@@ -47,6 +47,7 @@ import { SearchControls } from "../../components/SearchControls";
 import YearRangeFacet from "../../components/YearRangeFacet";
 import {
     conditionalFacets,
+    getSortByFromState,
     routeToState,
     stateToRoute,
     useCustomSearchkitSDK,
@@ -129,12 +130,7 @@ function EntitiesSearch() {
     useEffect(() => {
         // handle sorting separately in order to only update in case of changes
         if (sortState) {
-            let sortBy = sortState.field;
-            // relevance does not use direction
-            if (sortState.direction && sortBy !== "relevance") {
-                const dir = sortState.direction === 1 ? "asc" : "desc";
-                sortBy = `${sortState.field}_${dir}`;
-            }
+            const sortBy = getSortByFromState(sortState);
             if (
                 !searchParams.has("sort") ||
                 searchParams.get("sort") !== sortBy
@@ -161,6 +157,7 @@ function EntitiesSearch() {
                 stateToRoute({
                     ...variables,
                     query,
+                    sortBy: getSortByFromState(sortState),
                     scope,
                     operator,
                     page: {
@@ -175,6 +172,7 @@ function EntitiesSearch() {
             stateToRoute({
                 ...variables,
                 query,
+                sortBy: getSortByFromState(sortState),
                 scope,
                 operator,
                 page: {

--- a/src/pages/EntitiesSearchPage/EntitiesSearchPage.jsx
+++ b/src/pages/EntitiesSearchPage/EntitiesSearchPage.jsx
@@ -288,7 +288,7 @@ function EntitiesSearch() {
                                 isLoading={loading}
                                 onClick={() => {
                                     // reset query and filters
-
+                                    setQuery("");
                                     api.setQuery("");
                                     setYearRangeState({
                                         endYear: "",

--- a/src/pages/EntitiesSearchPage/EntitiesSearchPage.jsx
+++ b/src/pages/EntitiesSearchPage/EntitiesSearchPage.jsx
@@ -168,18 +168,20 @@ function EntitiesSearch() {
         }
     }, [operator]);
     useEffect(() => {
-        setSearchParams(
-            stateToRoute({
-                ...variables,
-                query,
-                sortBy: getSortByFromState(sortState),
-                scope,
-                operator,
-                page: {
-                    from: variables.page.from,
-                },
-            }),
-        );
+        if (variables?.page?.from) {
+            setSearchParams(
+                stateToRoute({
+                    ...variables,
+                    query,
+                    sortBy: getSortByFromState(sortState),
+                    scope,
+                    operator,
+                    page: {
+                        from: variables.page.from,
+                    },
+                }),
+            );
+        }
     }, [variables?.page?.from]);
 
     return (

--- a/src/pages/LettersSearchPage/LettersSearchPage.jsx
+++ b/src/pages/LettersSearchPage/LettersSearchPage.jsx
@@ -277,6 +277,7 @@ function LettersSearch() {
                                 isLoading={loading}
                                 onClick={() => {
                                     // reset query and date range
+                                    setQuery("");
                                     api.setQuery("");
                                     setDateRangeState({
                                         startDate: null,

--- a/src/pages/LettersSearchPage/LettersSearchPage.jsx
+++ b/src/pages/LettersSearchPage/LettersSearchPage.jsx
@@ -47,6 +47,7 @@ import "../../common/search.css";
 import SaveSearchButton from "../../components/SaveSearchButton";
 import { SearchControls } from "../../components/SearchControls";
 import {
+    getSortByFromState,
     routeToState,
     stateToRoute,
     useCustomSearchkitSDK,
@@ -131,12 +132,7 @@ function LettersSearch() {
     useEffect(() => {
         // handle sorting separately in order to only update in case of changes
         if (sortState) {
-            let sortBy = sortState.field;
-            // relevance does not use direction
-            if (sortState.direction && sortBy !== "relevance") {
-                const dir = sortState.direction === 1 ? "asc" : "desc";
-                sortBy = `${sortState.field}_${dir}`;
-            }
+            const sortBy = getSortByFromState(sortState);
             if (
                 !searchParams.has("sort") ||
                 searchParams.get("sort") !== sortBy
@@ -163,6 +159,7 @@ function LettersSearch() {
                 stateToRoute({
                     ...variables,
                     query,
+                    sortBy: getSortByFromState(sortState),
                     scope,
                     operator,
                     page: {
@@ -177,6 +174,7 @@ function LettersSearch() {
             stateToRoute({
                 ...variables,
                 query,
+                sortBy: getSortByFromState(sortState),
                 scope,
                 operator,
                 page: {

--- a/src/pages/LettersSearchPage/LettersSearchPage.jsx
+++ b/src/pages/LettersSearchPage/LettersSearchPage.jsx
@@ -170,18 +170,20 @@ function LettersSearch() {
         }
     }, [operator]);
     useEffect(() => {
-        setSearchParams(
-            stateToRoute({
-                ...variables,
-                query,
-                sortBy: getSortByFromState(sortState),
-                scope,
-                operator,
-                page: {
-                    from: variables.page.from,
-                },
-            }),
-        );
+        if (variables?.page?.from) {
+            setSearchParams(
+                stateToRoute({
+                    ...variables,
+                    query,
+                    sortBy: getSortByFromState(sortState),
+                    scope,
+                    operator,
+                    page: {
+                        from: variables.page.from,
+                    },
+                }),
+            );
+        }
     }, [variables?.page?.from]);
 
     return (

--- a/src/pages/LettersSearchPage/useDateFilter.js
+++ b/src/pages/LettersSearchPage/useDateFilter.js
@@ -18,10 +18,10 @@ export function useDateFilter() {
     // if a filter already present on initialization, set initial state to that range
     const [dateRange, setDateRange] = useState({
         startDate: searchParams?.has("dateMin")
-            ? moment(searchParams.get("dateMin"))
+            ? moment.utc(searchParams.get("dateMin"))
             : null,
         endDate: searchParams?.has("dateMax")
-            ? moment(searchParams.get("dateMax"))
+            ? moment.utc(searchParams.get("dateMax"))
             : null,
     });
 

--- a/src/pages/LettersSearchPage/useDateFilter.js
+++ b/src/pages/LettersSearchPage/useDateFilter.js
@@ -88,6 +88,23 @@ export function useDateFilter() {
                     ...page,
                 });
             });
+        } else if (!(dateRange?.startDate || dateRange?.endDate)) {
+            // handle both dates cleared
+            setSearchParams((prevParams) => {
+                const state = routeToState(prevParams);
+                state.filters = state.filters.filter(
+                    (f) =>
+                        f.identifier !== "end_date" &&
+                        f.identifier !== "start_date",
+                );
+                return stateToRoute({
+                    ...state,
+                    page: {
+                        size: 25,
+                        from: 0,
+                    },
+                });
+            });
         }
     }, [dateRange]);
 


### PR DESCRIPTION
## In this PR

Various bug fixes:
- Fix issue with links to saved searches sometimes failing (`useEffect` bug with pagination from variables that was causing state to update incorrectly and prematurely)
- Ensure sort state is retained on clicking the "back" button to navigate back to search results
- Use `moment.utc()` for all dates and fix issue with clearing both dates from a filter range
- Reset query text field on "reset search" click