### PR TITLE
Add timeline page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
                 "react": "^16.14.0",
                 "react-dom": "^16.14.0",
                 "react-icons": "^4.8.0",
-                "react-router-dom": "^6.4.3"
+                "react-router-dom": "^6.4.3",
+                "react-vertical-timeline-component": "^3.6.0"
             },
             "devDependencies": {
                 "@types/react": "^16.9.49",
@@ -5414,6 +5415,14 @@
                 "react": "^0.14.9 || ^15.3.0 || ^16.0.0-rc || ^16.0"
             }
         },
+        "node_modules/react-intersection-observer": {
+            "version": "8.34.0",
+            "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-8.34.0.tgz",
+            "integrity": "sha512-TYKh52Zc0Uptp5/b4N91XydfSGKubEhgZRtcg1rhTKABXijc4Sdr1uTp5lJ8TN27jwUsdXxjHXtHa0kPj704sw==",
+            "peerDependencies": {
+                "react": "^15.0.0 || ^16.0.0 || ^17.0.0|| ^18.0.0"
+            }
+        },
         "node_modules/react-is": {
             "version": "16.13.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -5552,6 +5561,17 @@
                 "@types/react": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/react-vertical-timeline-component": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/react-vertical-timeline-component/-/react-vertical-timeline-component-3.6.0.tgz",
+            "integrity": "sha512-l9zulqjIGlRuaQeplGzV4r/tG2RYBpYt84Il8w4IxnJze2cDIGI04MKo3F7f1sHT0Sih1ohEFts8UV23AJS15Q==",
+            "hasInstallScript": true,
+            "dependencies": {
+                "classnames": "^2.2.6",
+                "prop-types": "^15.7.2",
+                "react-intersection-observer": "^8.26.2"
             }
         },
         "node_modules/react-virtualized-auto-sizer": {
@@ -10844,6 +10864,12 @@
                 "prop-types": "^15.5.8"
             }
         },
+        "react-intersection-observer": {
+            "version": "8.34.0",
+            "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-8.34.0.tgz",
+            "integrity": "sha512-TYKh52Zc0Uptp5/b4N91XydfSGKubEhgZRtcg1rhTKABXijc4Sdr1uTp5lJ8TN27jwUsdXxjHXtHa0kPj704sw==",
+            "requires": {}
+        },
         "react-is": {
             "version": "16.13.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -10921,6 +10947,16 @@
                 "get-nonce": "^1.0.0",
                 "invariant": "^2.2.4",
                 "tslib": "^2.0.0"
+            }
+        },
+        "react-vertical-timeline-component": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/react-vertical-timeline-component/-/react-vertical-timeline-component-3.6.0.tgz",
+            "integrity": "sha512-l9zulqjIGlRuaQeplGzV4r/tG2RYBpYt84Il8w4IxnJze2cDIGI04MKo3F7f1sHT0Sih1ohEFts8UV23AJS15Q==",
+            "requires": {
+                "classnames": "^2.2.6",
+                "prop-types": "^15.7.2",
+                "react-intersection-observer": "^8.26.2"
             }
         },
         "react-virtualized-auto-sizer": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
         "react-icons": "^4.8.0",
-        "react-router-dom": "^6.4.3"
+        "react-router-dom": "^6.4.3",
+        "react-vertical-timeline-component": "^3.6.0"
     },
     "devDependencies": {
         "@types/react": "^16.9.49",

--- a/src/assets/index.css
+++ b/src/assets/index.css
@@ -16,3 +16,13 @@
 sup {
     vertical-align: super !important;
 }
+
+main {
+    /* margin-top: 48px; */
+}
+
+.result-name {
+    background-color: #fafbfd;
+    padding: 1rem 0;
+    top: 48px;
+}

--- a/src/components/Navigation.css
+++ b/src/components/Navigation.css
@@ -1,3 +1,9 @@
+header {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+}
+
 header a button.home {
     font-size: 1.25rem;
     font-weight: bold;

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -55,6 +55,13 @@ function Navigation() {
                                     </EuiHeaderLink>
                                 )}
                             </NavLink>
+                            <NavLink to="/timeline" tabIndex="-1">
+                                {({ isActive }) => (
+                                    <EuiHeaderLink isActive={isActive}>
+                                        Timeline
+                                    </EuiHeaderLink>
+                                )}
+                            </NavLink>
                         </EuiHeaderLinks>
                     </EuiHeaderSectionItem>
                 </EuiHeaderSection>

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -27,7 +27,7 @@ appendIconComponentCache({
  */
 function Navigation() {
     return (
-        <header>
+        <header className="main-nav-header">
             <EuiHeader>
                 <EuiHeaderSection>
                     <EuiHeaderSectionItem border="none">

--- a/src/components/TimelineYear.css
+++ b/src/components/TimelineYear.css
@@ -1,0 +1,36 @@
+:root {
+    --default-padding: 16px;
+    --sticky-pos: 10px;
+    --header-height: 3rem;
+}
+
+.sticky-timeline-header {
+    background-color: #fafbfd;
+    display: flex;
+    position: sticky;
+    top: 0px;
+    z-index: 1;
+}
+
+.sticky-timeline-header .euiText {
+    width: 100%;
+}
+
+.sticky-bumper {
+    position: absolute;
+    left: 0;
+    right: 0;
+    visibility: hidden;
+}
+
+.sticky-bumper-top {
+    height: var(--header-height);
+    top: calc(var(--header-height) * -1);
+    background-color: deeppink;
+}
+
+.sticky-bumper-bottom {
+    bottom: var(--header-height);
+    height: var(--header-height);
+    background-color: blueviolet;
+}

--- a/src/components/TimelineYear.jsx
+++ b/src/components/TimelineYear.jsx
@@ -1,0 +1,134 @@
+import { EuiText, EuiTextAlign } from "@elastic/eui";
+import {
+    VerticalTimeline,
+    VerticalTimelineElement,
+} from "react-vertical-timeline-component";
+
+import React, { useEffect, useRef } from "react";
+import "./TimelineYear.css";
+/**
+ * React component for displaying a timeline for a year.
+ * Much of the intersection observer logic is based on
+ * https://developer.chrome.com/blog/sticky-headers/
+ *
+ * @param {object} props React functional components props object
+ * @param {HTMLElement} props.root Container for all timelines
+ * @param {object} props.data Object with all the events for the given year
+ * @param {string} props.currentYear Year that is currently in the viewport
+ * @param {Function} props.setCurrentYear Function to set the value for currentYear
+ * @returns {React.Component} React functional component for a timeline
+ */
+function TimelineYear({ data, root, currentYear, setCurrentYear }) {
+    const headerRef = useRef();
+    const bumperTopRef = useRef();
+    const bumperBottomRef = useRef();
+    const id = `year-${data.year}`;
+
+    useEffect(() => {
+        // Observer for the top bumpers that updates the current year while scrolling down.
+        const topObserver = new IntersectionObserver(
+            ([record]) => {
+                const { boundingClientRect, rootBounds } = record;
+
+                if (
+                    boundingClientRect.bottom < rootBounds.top &&
+                    currentYear !== id
+                ) {
+                    setCurrentYear(id);
+                }
+            },
+            { threshold: [0], root },
+        );
+
+        // Observer for the bottom bumpers that updates the current year while scrolling up.
+        const bottomObserver = new IntersectionObserver(
+            ([record]) => {
+                const { boundingClientRect, rootBounds, intersectionRatio } =
+                    record;
+
+                if (
+                    boundingClientRect.bottom > rootBounds.top &&
+                    intersectionRatio === 1 &&
+                    currentYear !== id
+                ) {
+                    setCurrentYear(id);
+                }
+            },
+            { threshold: [1], root },
+        );
+
+        if (bumperTopRef.current) topObserver.observe(bumperTopRef.current);
+        if (bumperBottomRef.current)
+            bottomObserver.observe(bumperBottomRef.current);
+
+        return () => {
+            topObserver.disconnect();
+            bottomObserver.disconnect();
+        };
+    }, []);
+
+    return (
+        <section
+            id={`year-${data.year}`}
+            style={{ position: "relative" }}
+            ref={headerRef}
+        >
+            <header className="sticky-timeline-header">
+                <EuiText>
+                    <EuiTextAlign textAlign="center">
+                        <h1>{data.year}</h1>
+                    </EuiTextAlign>
+                </EuiText>
+            </header>
+            <VerticalTimeline lineColor="#b1b3b3" animate={false}>
+                {data.events.map((event) => {
+                    const color =
+                        event.type === "personal" ? "#007dba" : "#e6b965";
+                    return (
+                        <VerticalTimelineElement
+                            key={event.id}
+                            position={
+                                event.type === "personal" ? "left" : "right"
+                            }
+                            iconStyle={{
+                                background: color,
+                                marginTop: "-10px",
+                            }}
+                            contentArrowStyle={{
+                                borderRight: `7px solid  ${color}`,
+                                top: "10px",
+                            }}
+                            contentStyle={{
+                                borderColor: color,
+                                borderStyle: "solid",
+                                borderWidth: "thin",
+                                boxShadow: "none",
+                                padding: "0",
+                            }}
+                            className={`timeline-event timeline-event-type-${event.type}`}
+                        >
+                            <h2>{event.date}</h2>
+                            <p
+                                // eslint-disable-next-line react/no-danger
+                                dangerouslySetInnerHTML={{
+                                    __html: event.description,
+                                }}
+                            />
+                        </VerticalTimelineElement>
+                    );
+                })}
+            </VerticalTimeline>
+            {/* These elements mark the top and bottom of the time line and help determine the currentYear */}
+            <div
+                className="sticky-bumper sticky-bumper-top"
+                ref={bumperTopRef}
+            />
+            <div
+                className="sticky-bumper sticky-bumper-bottom"
+                ref={bumperBottomRef}
+            />
+        </section>
+    );
+}
+
+export default TimelineYear;

--- a/src/data/timelineData.js
+++ b/src/data/timelineData.js
@@ -1,0 +1,679 @@
+export const timelineData = [
+    {
+        year: 1946,
+        events: [
+            {
+                id: "ef11cfa8-aa22-5856-93a0-fbb0284e473c",
+                type: "personal",
+                description:
+                    "Samuel Beckett officially resigns from Irish Red Cross Hospital at Saint-Lô, but continues to assist it in Paris.",
+                date: "1 January",
+            },
+            {
+                id: "8fa951b5-397e-5520-a589-ae40e2f4208f",
+                type: "global",
+                date: "10 January",
+                description:
+                    "First United Nations General Assembly held in London; fifty-one countries are represented.",
+            },
+            {
+                id: "76a980f9-aa07-5447-a925-d8be76b25082",
+                type: "global",
+                date: "1 February",
+                description:
+                    "The National Assembly of Hungary abolishes the monarchy and proclaims the Republic of Hungary (1946-1949).",
+            },
+            {
+                id: "1dfc654f-bb7c-523b-a3cb-d0e05e6a9adf",
+                type: "personal",
+                description:
+                    'Samuel Beckett changes from writing in English to writing in French, in the manuscript of the novella that will become "Suite / Fin."',
+                date: "17 February",
+            },
+            {
+                id: "d42773c8-90f3-5a86-bc38-243d91682818",
+                type: "personal",
+                description:
+                    "London literary agent A. P. Watt confirms receipt of Watt, sent to him by Leslie Daiken.",
+                date: "22 February",
+            },
+            {
+                id: "c38dffed-c120-5620-8c69-bc7f00cf2aef",
+                type: "personal",
+                description:
+                    "Geer van Velde exhibition at the Galerie Maeght, Paris.",
+                date: "March-April",
+            },
+            {
+                id: "7275e4f3-560d-552c-8968-826a0674caa7",
+                type: "global",
+                date: "6 March",
+                description:
+                    "Ho Chi Minh sings an agreement with France recognizing Vietnam as an autonomous state in the Indochinese Federation and the French Union.",
+            },
+            {
+                id: "46888e54-d6af-5a09-bd67-791f9b6ce26f",
+                type: "personal",
+                description:
+                    'Samuel Beckett continues to write "Suite / Fin," but in French.',
+                date: "13 March",
+            },
+            {
+                id: "36f40cb8-d39e-5ae6-b014-4d6d7e53348f",
+                type: "personal",
+                description:
+                    "Bram van Velde exhibition opens at the Galerie Mai, Paris.",
+                date: "21 March",
+            },
+            {
+                id: "d193f28d-1cb9-5e18-8129-560bcafb268a",
+                type: "personal",
+                description: "Chatto and Windus rejects Watt.",
+                date: "8 April",
+            },
+            {
+                id: "d17a6d45-6b75-59cb-acea-cd87128d7f5f",
+                type: "personal",
+                description:
+                    "Samuel Beckett in London, before traveling to Dublin",
+                date: "Before 21 April",
+            },
+            {
+                id: "82581b7d-37e4-5043-8eab-5778a77e6798",
+                type: "personal",
+                description: "Beckett begins writing Mercier et Camier.",
+                date: "5 May 1946",
+            },
+            {
+                id: "a478e2f9-a4fc-58f3-853a-ceff0cb763a7",
+                type: "personal",
+                description:
+                    'The first part of "Suite" accepted by Les Temps Modernes.',
+                date: "before 15 May",
+            },
+            {
+                id: "cbc393e2-0bff-5461-8528-ca04270539e2",
+                type: "personal",
+                description:
+                    "Methuen is considering Watt, and publisher Maurice Fridberg in Dublin is interested in reading Watt.",
+                date: "19 June",
+            },
+            {
+                id: "5e4a9e85-6bb6-505b-9c9b-955427974cdc",
+                type: "personal",
+                description:
+                    'Beckett\'s  poem "Saint-Lô" published in The Irish Times.',
+                date: "24 June",
+            },
+            {
+                id: "9ad27688-7d47-5c15-80cf-32cf7f332b2b",
+                type: "personal",
+                description: "Samuel Beckett returns to Paris.",
+                date: "29 June",
+            },
+            {
+                id: "c13419cc-ccf4-579d-a178-754932539e8b",
+                type: "personal",
+                description:
+                    'Writes to Jacoba van Velde that the second part of "Suite" has been finished.',
+                date: "30 June",
+            },
+            {
+                id: "4eccd1d8-f48c-555f-8ec3-1c97c7e275d9",
+                type: "personal",
+                description:
+                    "First part of Suite published in Les Temps Modernes.",
+                date: "July",
+            },
+            {
+                id: "1aea24ee-28ba-5abe-8c25-a8235b3a2a95",
+                type: "personal",
+                description:
+                    'Samuel Beckett sends second part of "Suite" to Les Temps Modernes.',
+                date: "2 July",
+            },
+            {
+                id: "ede76421-8a44-5cf7-bf4d-36b2908bd3ea",
+                type: "personal",
+                description: "Writes to Routledge requesting copies of Murphy.",
+                date: "28 August",
+            },
+            {
+                id: "8806fa54-3eeb-5eb2-9635-c50f5040c4f8",
+                type: "personal",
+                description:
+                    "Routledge indicates that Murphy went out of print in 1942.",
+                date: "before 1 September",
+            },
+            {
+                id: "dcd8256f-8a73-5013-a81e-e09d21ba095f",
+                type: "personal",
+                description: "Methuen rejects Watt.",
+                date: "3 September",
+            },
+            {
+                id: "0ab88fd5-438d-5d76-8499-e70d91c95396",
+                type: "personal",
+                description:
+                    'Samuel Beckett writes to Simone de Beauvoir protesting her unwillingness to publish the second part of "Suite" in Les Temps Modernes.',
+                date: "25 September",
+            },
+            {
+                id: "6bcca584-0507-5c49-be5f-85a571020a08",
+                type: "personal",
+                description:
+                    "Final date in second notebook of MS of Mercier et Camier.",
+                date: "26 September",
+            },
+            {
+                id: "32791cf7-1ae0-512f-9285-7b957107094d",
+                type: "personal",
+                description:
+                    "Samuel Beckett and Suzanne Deschevaux-Dumesnil in Abondant, occupying the cottage of André and Ruth Salzman.",
+                date: "October",
+            },
+            {
+                id: "5c3f889d-e91d-5438-a10d-7c1fc0d91480",
+                type: "personal",
+                description:
+                    '"La peinture des van Velde ou le monde et le Pantalon" published in Cahiers d\'Art.',
+                date: "October",
+            },
+            {
+                id: "b8feb34a-ad99-5efb-862a-a5e3731c7bad",
+                type: "global",
+                date: "1 October",
+                description: "Nazi leaders sentenced at Nuremberg trials.",
+            },
+            {
+                id: "97eb7b17-044a-5159-aa91-6e67ad1866cd",
+                type: "personal",
+                description: "Samuel Beckett revises Mercier et Camier.",
+                date: "before 13 October",
+            },
+            {
+                id: "c4ed9efa-a657-592c-85cb-ca8b571e86bd",
+                type: "personal",
+                description:
+                    'Has received proofs of "Poèmes 38 39" from Les Temps Modernes.',
+                date: "by 13 October",
+            },
+            {
+                id: "986b7ecf-0223-53cf-9591-98e379f6babb",
+                type: "personal",
+                description: 'Beckett writes "L\'Expulsé."',
+                date: "6-14 October",
+            },
+            {
+                id: "5a3f397d-3761-5477-bd61-819a57be867f",
+                type: "personal",
+                description: "Returns to Paris from Abondant.",
+                date: "16 October",
+            },
+            {
+                id: "f60adbad-c811-5a2b-8ecf-601c4b9ec643",
+                type: "personal",
+                description: 'Begins writing "Premier Amour"',
+                date: "28 October",
+            },
+            {
+                id: "cff2fda6-7e0a-58a2-b6ac-fca4f461eba3",
+                type: "personal",
+                description:
+                    "Pierre Bordas sends Samuel Beckett contract for Murphy and future work.",
+                date: " 29 October",
+            },
+            {
+                id: "af260da6-aab1-50cc-8d6f-814c96e0eae6",
+                type: "personal",
+                description:
+                    'Les Temps Modernes publishes the twelve "Poèmes 38-39."',
+                date: "November",
+            },
+            {
+                id: "5560cbf8-7703-5999-be21-6b8ecdd1b83a",
+                type: "global",
+                date: "4 November",
+                description:
+                    "UNESCO charter in force (ratified by twenty countries).",
+            },
+            {
+                id: "790d90cf-0e36-50ab-81ae-681f2bf9ccf5",
+                type: "personal",
+                description: 'Samuel Beckett completes "Premier Amour."',
+                date: "12 November",
+            },
+            {
+                id: "7642c37a-583f-5f71-803a-7d4cb4508393",
+                type: "personal",
+                description: "Goes to Abondant.",
+                date: "19 November",
+            },
+            {
+                id: "0ae77144-b6af-546a-9a5c-eccafa8181d7",
+                type: "personal",
+                description: 'Sends "Premier amour" to Jacoba van Velde.',
+                date: "before 3 December",
+            },
+            {
+                id: "de2fc783-90cb-5146-880f-7062ef60c61c",
+                type: "global",
+                date: "9 December",
+                description:
+                    "The Constitutent Assembly of India meets for the first time to write the Constitution of India.",
+            },
+            {
+                id: "1160dbe3-a2d1-5315-ae47-be5e5fdcc71b",
+                type: "personal",
+                description:
+                    "Samuel Beckett sends Mercier et Camier to Editions Bordas.",
+                date: "15 December",
+            },
+            {
+                id: "1fdcdf2d-c32d-5d4b-b6b4-d2dc70cca8cb",
+                type: "personal",
+                description: "Returns to Paris from Abondant.",
+                date: "c. 16-17 December",
+            },
+            {
+                id: "d483d5a4-5d33-516e-85fa-772e17d66ba4",
+                type: "personal",
+                description: 'Begins writing "Le Calmant."',
+                date: "23 December",
+            },
+            {
+                id: "bef91045-bd22-530a-a2d0-a06cef9dc58b",
+                type: "personal",
+                description: '"L\'Expulsé" published in Fontaine.',
+                date: "December",
+            },
+        ],
+    },
+    {
+        year: 1947,
+        events: [
+            {
+                id: "8fa40ef1-3a69-55c9-a1dc-3b9d42f3a5af",
+                type: "personal",
+                description:
+                    "Editions Bordas gives Samuel Beckett an advance for Mercier et Camier.",
+                date: "January",
+            },
+            {
+                id: "7a6dc7ca-2a42-5579-ab17-fb5f68bf4495",
+                type: "personal",
+                description:
+                    "Samuel Beckett begins writing his play Eleutheria.",
+                date: "18 January",
+            },
+            {
+                id: "cac66f0b-4da1-5d25-80fe-b913f5e58ab4",
+                type: "personal",
+                description: "Finishes Eleutheria.",
+                date: "24 February",
+            },
+            {
+                id: "03c6c01d-454b-5dd5-9c1c-456360214aa3",
+                type: "personal",
+                description:
+                    "Travels to London, where he stays with George Reavey for a few days, before going to Dublin on 14 April.",
+                date: "before 14 April",
+            },
+            {
+                id: "2d297b1a-fb5b-584a-81c9-e5e196ff6094",
+                type: "personal",
+                description:
+                    "Imprint date of French edition of Murphy (Bordas).",
+                date: "15 April",
+            },
+            {
+                id: "edc31394-f815-5298-be20-a71e59f53a04",
+                type: "personal",
+                description:
+                    "Exhibition of French Painting, Waddington Gallery, Dublin, including three paintings by Geer van Velde.",
+                date: "May",
+            },
+            {
+                id: "ad2720a6-4849-57d1-bbd4-b61fa6324bc8",
+                type: "personal",
+                description: "Samuel Beckett begins writing Molloy.",
+                date: "2 May",
+            },
+            {
+                id: "2fafb5f2-6be1-57ef-9b05-4f9b4885a13d",
+                type: "personal",
+                description: "Flies from Dublin to Paris.",
+                date: "5 July",
+            },
+            {
+                id: "eed46588-9ac6-5fbb-a533-685e8295820d",
+                type: "personal",
+                description:
+                    "Samuel Beckett and Suzanne Deschevaux-Dumesnil go to Menton. Samuel Beckett works on Molloy there. ",
+                date: "23 July ",
+            },
+            {
+                id: "c378f8e2-f571-5523-89d3-ca8beff8f271",
+                type: "global",
+                date: "14 August",
+                description:
+                    "Pakistan gains independence from the British Empire and joins the Commonwealth of Nations.",
+            },
+            {
+                id: "2d9eb0d7-3482-5422-8b0d-df02013f4d26",
+                type: "global",
+                date: "15 August",
+                description:
+                    "India gains independence from the British Empire and joins the Commonwealth of Nations.",
+            },
+            {
+                id: "4d5ad892-b051-5a2b-9823-14d0cae82f8a",
+                type: "personal",
+                description: "Jean Vilar is reading Eleutheria.",
+                date: "15 August",
+            },
+            {
+                id: "cc02b0cd-16a3-5634-bf12-81d0d498cfb5",
+                type: "personal",
+                description:
+                    "London publisher Hamish Hamilton is considering Watt.",
+                date: "27 August",
+            },
+            {
+                id: "c41b86c6-f0dd-505d-8c74-a7b72f4f0a7f",
+                type: "personal",
+                description: "Samuel Beckett returns to Paris from Menton.",
+                date: "end of September",
+            },
+            {
+                id: "f209322b-1f81-5319-8184-30a11a45c5c2",
+                type: "global",
+                date: "20 October",
+                description:
+                    "In the United States, the House Un-American Activities Committee begins investigation into Communism in Hollywood.",
+            },
+            {
+                id: "2d9e88f6-3f75-54eb-b756-8dc04357d0af",
+                type: "personal",
+                description: "Samuel Beckett finishes Molloy.",
+                date: "1 November",
+            },
+            {
+                id: "3e8c812b-fc25-5473-ae65-5ad5b544a3e1",
+                type: "global",
+                date: "18 November",
+                description:
+                    "First day of National Strikes in France that will last through the winter of 1947-1948.",
+            },
+            {
+                id: "1c54ee36-b15c-5e42-b539-a88d7886f37f",
+                type: "personal",
+                description:
+                    "Hamish Hamilton has rejected Watt. Maria Jolas has asked Samuel Beckett to translate for the new Transition.",
+                date: "by 24 November",
+            },
+            {
+                id: "6eac80a1-8eeb-592b-a5d6-d87b5cb0fb86",
+                type: "personal",
+                description:
+                    "Samuel Beckett begins Malone meurt. The Grenier-Hussenot theatre, Paris, interested in Eleutheria.",
+                date: "27 November",
+            },
+        ],
+    },
+    {
+        year: 1948,
+        events: [
+            {
+                id: "318fa452-fd82-5fd4-8641-1cee0cf8abb0",
+                type: "personal",
+                description:
+                    "Samuel Beckett unable to receive money in France from Irish Bank; applies to UNESCO for employment.",
+                date: "before 4 January",
+            },
+            {
+                id: "95f575b8-519e-5e3c-bee5-b57e968ea244",
+                type: "personal",
+                description:
+                    "Pierre Bordas informs Jacoba van Velde, acting as Beckett's agent, that he cannot publish Molloy immediately.",
+                date: "13 January",
+            },
+            {
+                id: "8e749631-c4b7-586c-8157-01d1edbcc074",
+                type: "global",
+                date: "30 January",
+                description: "Assassination of Mahatma Gandhi.",
+            },
+            {
+                id: "a3c1de90-40f8-5ae4-be96-d8025e80ff0d",
+                type: "personal",
+                description:
+                    "Bram and Geer van Velde exhibition, Kootz Gallery, New York; Samuel Beckett writes text for the invitation card.",
+                date: "8-27 March",
+            },
+            {
+                id: "640deb8e-8f31-5079-9a8c-a8d9aae3df89",
+                type: "personal",
+                description:
+                    "Samuel Beckett's \"Peintres de l'empêchement\" published in Derrière le Miroir.",
+                date: "May",
+            },
+            {
+                id: "17db76c5-3dfe-5a22-ada3-e687262b323a",
+                type: "global",
+                date: "14 May",
+                description: "Declaration of the State of Israel.",
+            },
+            {
+                id: "f07d3c70-f993-5976-8f87-cf2322df16cc",
+                type: "personal",
+                description:
+                    "Samuel Beckett takes Georges Duthuit to see Bram van Velde's work.",
+                date: "21 May",
+            },
+            {
+                id: "7a37a2e3-9faf-5da2-bb0f-61c9d20f6015",
+                type: "personal",
+                descriptions: "Finishes Malone meurt.",
+                date: "30 May",
+            },
+            {
+                id: "e5e7f98d-8810-5e6d-acde-599a4315113e",
+                type: "personal",
+                description:
+                    "Opening of Geer and Bram van Velde exhibition, Galerie Maeght.",
+                date: "4 June",
+            },
+            {
+                id: "34be3b18-206c-53d3-b400-06aa83c56abc",
+                type: "personal",
+                description:
+                    'Samuel Beckett\'s "Three poems" published in Transition Forty-Eight, no. 2.',
+                date: "15 June",
+            },
+            {
+                id: "39b19704-8843-54f1-9943-9d2eeb3fc74f",
+                type: "personal",
+                description:
+                    "MacGreevy in Paris. Samuel Beckett attends Andromaque with him at the Comédie-Française.",
+                date: "21-28 June",
+            },
+            {
+                id: "9f80bb5d-2ef9-5ccd-a82a-6bb1f72e5b78",
+                type: "global",
+                date: "24 June 1948 – 12 May 1949",
+                description:
+                    "Berlin Blockade by the Soviet Union forces in East Germany results in the Berlin Airlift to deliver supplies to West Berlin by Western Allies. ",
+            },
+            {
+                id: "497f7358-234a-52e2-b5f6-5aedb9b5c48c",
+                type: "personal",
+                description: "Samuel Beckett retyping Malone meurt.",
+                date: "8 July",
+            },
+            {
+                id: "136bd15e-be75-5dae-bc05-21a42978da35",
+                type: "personal",
+                description: "Travels to Dublin.",
+                date: "14 July",
+            },
+            {
+                id: "89c05921-4de5-5dd2-ab14-c79d7c56fb0b",
+                type: "personal",
+                description:
+                    "MacGreevy awarded Chevalier de l'Ordre de la Légion d'Honneur for his services to the arts.",
+                date: "19 July",
+            },
+            {
+                id: "5518490f-91d0-5911-9ad0-7fdb256d69f0",
+                type: "personal",
+                description:
+                    "Samuel Beckett attends the private viewing of the Irish Exhibition of Living Art at the National College of Art.",
+                date: "11 August",
+            },
+            {
+                id: "facfdcd3-d947-5ddc-bed2-f8741f4fc057",
+                type: "personal",
+                description: "Travels from Dublin to Paris.",
+                date: "c. 1 September",
+            },
+            {
+                id: "49e7656a-42d0-5268-9f29-a987f0d01ccd",
+                type: "personal",
+                description: "Finishes retyping Malone meurt.",
+                date: "29 September",
+            },
+            {
+                id: "d882b656-dfcd-55f5-9a5a-473720576d2b",
+                type: "personal",
+                description:
+                    "Samuel Beckett begins writing En attendant Godot.",
+                date: "9 October",
+            },
+            {
+                id: "086fb591-2057-5295-9c31-944f74f89595",
+                type: "personal",
+                description: "Patrick Waldberg reviews Murphy in Paru.",
+                date: "November",
+            },
+            {
+                id: "fea08f9d-892e-5b29-8d0a-72bdba477546",
+                type: "personal",
+                description:
+                    'Death of Arthur Darley. Shortly after, Samuel Beckett writes the poem "Mort de A.D."',
+                date: "30 December",
+            },
+        ],
+    },
+    {
+        year: 1949,
+        events: [
+            {
+                id: "d8129ce8-6f4c-59de-bcad-1622eadb1f46",
+                description:
+                    "Samuel Beckett finishes writing En attendant Godot.",
+                date: "29 January",
+                type: "personal",
+            },
+            {
+                id: "eaf959d9-939e-5de6-ae8a-aa65c1f1fdc8",
+                description:
+                    "Bram and Geer van Velde exhibition at the Galerie Folklore, Lyon.",
+                date: "February",
+                type: "personal",
+            },
+            {
+                id: "00055401-cfa2-571b-bdf1-7a6df1eb7711",
+                description:
+                    'Samuel Beckett submits Eleutheria for the Prix Rivarol; the play is being read by director Raymond Rouleau. Begins retyping En attendant Godot. Translates Guillaume Apollinaire\'s poem "Zone."',
+                date: "before 27 March",
+                type: "personal",
+            },
+            {
+                id: "3993e10d-2a11-59cb-83f3-23a496a66d52",
+                description:
+                    "Samuel Beckett and Suzanne Deschevaux-Dumesnil take a room in a farmhouse in Ussy-sur-Marne.",
+                date: "by 27 March",
+                type: "personal",
+            },
+            {
+                id: "9e14e61f-13ac-51b9-baea-953dd7a25bcf",
+                description: "Samuel Beckett begins writing L'Innommable.",
+                date: "29 March",
+                type: "personal",
+            },
+            {
+                id: "16d1c0a0-b336-5ce1-8c14-f6da91dc8289",
+                description: '"\'Three poems" published in Poetry Ireland.',
+                date: "April",
+                type: "personal",
+            },
+            {
+                id: "e400648f-a8ab-51c1-b3d9-db9a90d85770",
+                type: "global",
+                date: "1 April",
+                description:
+                    "The twenty-six counties of the Irish Free State become the Republic of Ireland.",
+            },
+            {
+                id: "daaebac1-0c5d-5de2-ae81-5578e24f95bd",
+                type: "global",
+                date: "12 May",
+                description: "Berlin blockade lifted.",
+            },
+            {
+                id: "4e3bd6a6-ee45-594e-b9b7-e17eb670c32f",
+                type: "global",
+                date: "23 May",
+                description:
+                    "West Germany becomes the Federal Republic of Germany.",
+            },
+            {
+                id: "dd572afa-b4f4-5c93-9434-32c71b7b3253",
+                type: "personal",
+                decription:
+                    "Samuel Beckett begins translations for Sélection, the French edition of The Reader's Digest.",
+                date: "before 1 June",
+            },
+            {
+                id: "ab47b49f-b028-55c1-b715-68759c02ed0e",
+                description:
+                    'Begins working on "Three Dialogues" with Georges Duthuit.',
+                date: "June",
+                type: "personal",
+            },
+            {
+                id: "155c207b-9f90-5bd3-857e-a6836ea35db7",
+                description: "Charles Prentice dies in Nairobi.",
+                date: "30 June",
+                type: "personal",
+            },
+            {
+                id: "b0c83f65-f6a9-51c0-919b-2b5bba55c029",
+                description: "Samuel Beckett in Dublin.",
+                date: "July",
+                type: "personal",
+            },
+            {
+                id: "b0fbed0b-d22f-583f-a96c-4da7bf05fd2c",
+                description: "Flies from Dublin to Paris.",
+                date: "1 August",
+                type: "personal",
+            },
+            {
+                id: "696e73a1-0561-5c95-929d-be3831a9ca4b",
+                description:
+                    "Beckett sends an extract from Watt to John Ryan, editor of Envoy.",
+                date: "20 October",
+                type: "personal",
+            },
+            {
+                id: "f65018fe-34a9-572f-9829-60ecad9efd4d",
+                description:
+                    '"Three Dialogues" published in Transition Forty-Nine, no. 5.',
+                date: "10 December",
+                type: "personal",
+            },
+        ],
+    },
+];

--- a/src/data/timelineData.js
+++ b/src/data/timelineData.js
@@ -34,7 +34,7 @@ export const timelineData = [
                 id: "d42773c8-90f3-5a86-bc38-243d91682818",
                 type: "personal",
                 description:
-                    "London literary agent A. P. Watt confirms receipt of Watt, sent to him by Leslie Daiken.",
+                    "London literary agent A. P. Watt confirms receipt of <i>Watt</i>, sent to him by Leslie Daiken.",
                 date: "22 February",
             },
             {
@@ -68,7 +68,7 @@ export const timelineData = [
             {
                 id: "d193f28d-1cb9-5e18-8129-560bcafb268a",
                 type: "personal",
-                description: "Chatto and Windus rejects Watt.",
+                description: "Chatto and Windus rejects <i>Watt</i>.",
                 date: "8 April",
             },
             {
@@ -81,28 +81,28 @@ export const timelineData = [
             {
                 id: "82581b7d-37e4-5043-8eab-5778a77e6798",
                 type: "personal",
-                description: "Beckett begins writing Mercier et Camier.",
+                description: "Beckett begins writing <i>Mercier et Camier</i>.",
                 date: "5 May 1946",
             },
             {
                 id: "a478e2f9-a4fc-58f3-853a-ceff0cb763a7",
                 type: "personal",
                 description:
-                    'The first part of "Suite" accepted by Les Temps Modernes.',
+                    'The first part of "Suite" accepted by <i>Les Temps Modernes</i>.',
                 date: "before 15 May",
             },
             {
                 id: "cbc393e2-0bff-5461-8528-ca04270539e2",
                 type: "personal",
                 description:
-                    "Methuen is considering Watt, and publisher Maurice Fridberg in Dublin is interested in reading Watt.",
+                    "Methuen is considering <i>Watt</i>, and publisher Maurice Fridberg in Dublin is interested in reading <i>Watt</i>.",
                 date: "19 June",
             },
             {
                 id: "5e4a9e85-6bb6-505b-9c9b-955427974cdc",
                 type: "personal",
                 description:
-                    'Beckett\'s  poem "Saint-Lô" published in The Irish Times.',
+                    'Beckett\'s  poem "Saint-Lô" published in <i>The Irish Times</i>.',
                 date: "24 June",
             },
             {
@@ -122,47 +122,48 @@ export const timelineData = [
                 id: "4eccd1d8-f48c-555f-8ec3-1c97c7e275d9",
                 type: "personal",
                 description:
-                    "First part of Suite published in Les Temps Modernes.",
+                    "First part of Suite published in <i>Les Temps Modernes</i>.",
                 date: "July",
             },
             {
                 id: "1aea24ee-28ba-5abe-8c25-a8235b3a2a95",
                 type: "personal",
                 description:
-                    'Samuel Beckett sends second part of "Suite" to Les Temps Modernes.',
+                    'Samuel Beckett sends second part of "Suite" to <i>Les Temps Modernes</i>.',
                 date: "2 July",
             },
             {
                 id: "ede76421-8a44-5cf7-bf4d-36b2908bd3ea",
                 type: "personal",
-                description: "Writes to Routledge requesting copies of Murphy.",
+                description:
+                    "Writes to Routledge requesting copies of <i>Murphy</i>.",
                 date: "28 August",
             },
             {
                 id: "8806fa54-3eeb-5eb2-9635-c50f5040c4f8",
                 type: "personal",
                 description:
-                    "Routledge indicates that Murphy went out of print in 1942.",
+                    "Routledge indicates that <i>Murphy</i> went out of print in 1942.",
                 date: "before 1 September",
             },
             {
                 id: "dcd8256f-8a73-5013-a81e-e09d21ba095f",
                 type: "personal",
-                description: "Methuen rejects Watt.",
+                description: "Methuen rejects <i>Watt</i>.",
                 date: "3 September",
             },
             {
                 id: "0ab88fd5-438d-5d76-8499-e70d91c95396",
                 type: "personal",
                 description:
-                    'Samuel Beckett writes to Simone de Beauvoir protesting her unwillingness to publish the second part of "Suite" in Les Temps Modernes.',
+                    'Samuel Beckett writes to Simone de Beauvoir protesting her unwillingness to publish the second part of "Suite" in <i>Les Temps Modernes</i>.',
                 date: "25 September",
             },
             {
                 id: "6bcca584-0507-5c49-be5f-85a571020a08",
                 type: "personal",
                 description:
-                    "Final date in second notebook of MS of Mercier et Camier.",
+                    "Final date in second notebook of MS of <i>Mercier et Camier</i>.",
                 date: "26 September",
             },
             {
@@ -176,7 +177,7 @@ export const timelineData = [
                 id: "5c3f889d-e91d-5438-a10d-7c1fc0d91480",
                 type: "personal",
                 description:
-                    '"La peinture des van Velde ou le monde et le Pantalon" published in Cahiers d\'Art.',
+                    '"La peinture des van Velde ou le monde et le Pantalon" published in <i>Cahiers d\'Art</i>.',
                 date: "October",
             },
             {
@@ -188,14 +189,14 @@ export const timelineData = [
             {
                 id: "97eb7b17-044a-5159-aa91-6e67ad1866cd",
                 type: "personal",
-                description: "Samuel Beckett revises Mercier et Camier.",
+                description: "Samuel Beckett revises <i>Mercier et Camier</i>.",
                 date: "before 13 October",
             },
             {
                 id: "c4ed9efa-a657-592c-85cb-ca8b571e86bd",
                 type: "personal",
                 description:
-                    'Has received proofs of "Poèmes 38 39" from Les Temps Modernes.',
+                    'Has received proofs of "Poèmes 38 39" from <i>Les Temps Modernes</i>.',
                 date: "by 13 October",
             },
             {
@@ -220,14 +221,14 @@ export const timelineData = [
                 id: "cff2fda6-7e0a-58a2-b6ac-fca4f461eba3",
                 type: "personal",
                 description:
-                    "Pierre Bordas sends Samuel Beckett contract for Murphy and future work.",
+                    "Pierre Bordas sends Samuel Beckett contract for <i>Murphy</i> and future work.",
                 date: " 29 October",
             },
             {
                 id: "af260da6-aab1-50cc-8d6f-814c96e0eae6",
                 type: "personal",
                 description:
-                    'Les Temps Modernes publishes the twelve "Poèmes 38-39."',
+                    '<i>Les Temps Modernes</i> publishes the twelve "Poèmes 38-39."',
                 date: "November",
             },
             {
@@ -266,7 +267,7 @@ export const timelineData = [
                 id: "1160dbe3-a2d1-5315-ae47-be5e5fdcc71b",
                 type: "personal",
                 description:
-                    "Samuel Beckett sends Mercier et Camier to Editions Bordas.",
+                    "Samuel Beckett sends <i>Mercier et Camier</i> to Editions Bordas.",
                 date: "15 December",
             },
             {
@@ -284,7 +285,7 @@ export const timelineData = [
             {
                 id: "bef91045-bd22-530a-a2d0-a06cef9dc58b",
                 type: "personal",
-                description: '"L\'Expulsé" published in Fontaine.',
+                description: '"L\'Expulsé" published in <i>Fontaine</i>.',
                 date: "December",
             },
         ],
@@ -296,20 +297,20 @@ export const timelineData = [
                 id: "8fa40ef1-3a69-55c9-a1dc-3b9d42f3a5af",
                 type: "personal",
                 description:
-                    "Editions Bordas gives Samuel Beckett an advance for Mercier et Camier.",
+                    "Editions Bordas gives Samuel Beckett an advance for <i>Mercier et Camier</i>.",
                 date: "January",
             },
             {
                 id: "7a6dc7ca-2a42-5579-ab17-fb5f68bf4495",
                 type: "personal",
                 description:
-                    "Samuel Beckett begins writing his play Eleutheria.",
+                    "Samuel Beckett begins writing his play <i>Eleutheria</i>.",
                 date: "18 January",
             },
             {
                 id: "cac66f0b-4da1-5d25-80fe-b913f5e58ab4",
                 type: "personal",
-                description: "Finishes Eleutheria.",
+                description: "Finishes <i>Eleutheria</i>.",
                 date: "24 February",
             },
             {
@@ -336,7 +337,7 @@ export const timelineData = [
             {
                 id: "ad2720a6-4849-57d1-bbd4-b61fa6324bc8",
                 type: "personal",
-                description: "Samuel Beckett begins writing Molloy.",
+                description: "Samuel Beckett begins writing <i>Molloy</i>.",
                 date: "2 May",
             },
             {
@@ -349,7 +350,7 @@ export const timelineData = [
                 id: "eed46588-9ac6-5fbb-a533-685e8295820d",
                 type: "personal",
                 description:
-                    "Samuel Beckett and Suzanne Deschevaux-Dumesnil go to Menton. Samuel Beckett works on Molloy there. ",
+                    "Samuel Beckett and Suzanne Deschevaux-Dumesnil go to Menton. Samuel Beckett works on <i>Molloy</i> there. ",
                 date: "23 July ",
             },
             {
@@ -369,14 +370,14 @@ export const timelineData = [
             {
                 id: "4d5ad892-b051-5a2b-9823-14d0cae82f8a",
                 type: "personal",
-                description: "Jean Vilar is reading Eleutheria.",
+                description: "Jean Vilar is reading <i>Eleutheria</i>.",
                 date: "15 August",
             },
             {
                 id: "cc02b0cd-16a3-5634-bf12-81d0d498cfb5",
                 type: "personal",
                 description:
-                    "London publisher Hamish Hamilton is considering Watt.",
+                    "London publisher Hamish Hamilton is considering <i>Watt</i>.",
                 date: "27 August",
             },
             {
@@ -395,7 +396,7 @@ export const timelineData = [
             {
                 id: "2d9e88f6-3f75-54eb-b756-8dc04357d0af",
                 type: "personal",
-                description: "Samuel Beckett finishes Molloy.",
+                description: "Samuel Beckett finishes <i>Molloy</i>.",
                 date: "1 November",
             },
             {
@@ -409,14 +410,14 @@ export const timelineData = [
                 id: "1c54ee36-b15c-5e42-b539-a88d7886f37f",
                 type: "personal",
                 description:
-                    "Hamish Hamilton has rejected Watt. Maria Jolas has asked Samuel Beckett to translate for the new Transition.",
+                    "Hamish Hamilton has rejected <i>Watt</i>. Maria Jolas has asked Samuel Beckett to translate for the new <i>Transition</i>.",
                 date: "by 24 November",
             },
             {
                 id: "6eac80a1-8eeb-592b-a5d6-d87b5cb0fb86",
                 type: "personal",
                 description:
-                    "Samuel Beckett begins Malone meurt. The Grenier-Hussenot theatre, Paris, interested in Eleutheria.",
+                    "Samuel Beckett begins <i>Malone meurt</i>. The Grenier-Hussenot theatre, Paris, interested in <i>Eleutheria</i>.",
                 date: "27 November",
             },
         ],
@@ -435,7 +436,7 @@ export const timelineData = [
                 id: "95f575b8-519e-5e3c-bee5-b57e968ea244",
                 type: "personal",
                 description:
-                    "Pierre Bordas informs Jacoba van Velde, acting as Beckett's agent, that he cannot publish Molloy immediately.",
+                    "Pierre Bordas informs Jacoba van Velde, acting as Beckett's agent, that he cannot publish <i>Molloy</i> immediately.",
                 date: "13 January",
             },
             {
@@ -455,7 +456,7 @@ export const timelineData = [
                 id: "640deb8e-8f31-5079-9a8c-a8d9aae3df89",
                 type: "personal",
                 description:
-                    "Samuel Beckett's \"Peintres de l'empêchement\" published in Derrière le Miroir.",
+                    "Samuel Beckett's \"Peintres de l'empêchement\" published in <i>Derrière le Miroir</i>.",
                 date: "May",
             },
             {
@@ -473,7 +474,7 @@ export const timelineData = [
             },
             {
                 id: "7a37a2e3-9faf-5da2-bb0f-61c9d20f6015",
-                description: "Finishes Malone meurt.",
+                description: "Finishes <i>Malone meurt</i>.",
                 date: "30 May",
                 type: "personal",
             },
@@ -488,7 +489,7 @@ export const timelineData = [
                 id: "34be3b18-206c-53d3-b400-06aa83c56abc",
                 type: "personal",
                 description:
-                    'Samuel Beckett\'s "Three poems" published in Transition Forty-Eight, no. 2.',
+                    'Samuel Beckett\'s "Three poems" published in <i>Transition Forty-Eight</i>, no. 2.',
                 date: "15 June",
             },
             {
@@ -508,7 +509,7 @@ export const timelineData = [
             {
                 id: "497f7358-234a-52e2-b5f6-5aedb9b5c48c",
                 type: "personal",
-                description: "Samuel Beckett retyping Malone meurt.",
+                description: "Samuel Beckett retyping <i>Malone meurt</i>.",
                 date: "8 July",
             },
             {
@@ -540,20 +541,20 @@ export const timelineData = [
             {
                 id: "49e7656a-42d0-5268-9f29-a987f0d01ccd",
                 type: "personal",
-                description: "Finishes retyping Malone meurt.",
+                description: "Finishes retyping <i>Malone meurt</i>.",
                 date: "29 September",
             },
             {
                 id: "d882b656-dfcd-55f5-9a5a-473720576d2b",
                 type: "personal",
                 description:
-                    "Samuel Beckett begins writing En attendant Godot.",
+                    "Samuel Beckett begins writing <i>En attendant Godot</i>.",
                 date: "9 October",
             },
             {
                 id: "086fb591-2057-5295-9c31-944f74f89595",
                 type: "personal",
-                description: "Patrick Waldberg reviews Murphy in Paru.",
+                description: "Patrick Waldberg reviews <i>Murphy in Paru</i>.",
                 date: "November",
             },
             {
@@ -571,7 +572,7 @@ export const timelineData = [
             {
                 id: "d8129ce8-6f4c-59de-bcad-1622eadb1f46",
                 description:
-                    "Samuel Beckett finishes writing En attendant Godot.",
+                    "Samuel Beckett finishes writing <i>En attendant Godot</i>.",
                 date: "29 January",
                 type: "personal",
             },
@@ -585,7 +586,7 @@ export const timelineData = [
             {
                 id: "00055401-cfa2-571b-bdf1-7a6df1eb7711",
                 description:
-                    'Samuel Beckett submits Eleutheria for the Prix Rivarol; the play is being read by director Raymond Rouleau. Begins retyping En attendant Godot. Translates Guillaume Apollinaire\'s poem "Zone."',
+                    'Samuel Beckett submits <i>Eleutheria</i> for the Prix Rivarol; the play is being read by director Raymond Rouleau. Begins retyping <i>En attendant Godot</i>. Translates Guillaume Apollinaire\'s poem "Zone."',
                 date: "before 27 March",
                 type: "personal",
             },
@@ -598,13 +599,15 @@ export const timelineData = [
             },
             {
                 id: "9e14e61f-13ac-51b9-baea-953dd7a25bcf",
-                description: "Samuel Beckett begins writing L'Innommable.",
+                description:
+                    "Samuel Beckett begins writing <i>L'Innommable</i>.",
                 date: "29 March",
                 type: "personal",
             },
             {
                 id: "16d1c0a0-b336-5ce1-8c14-f6da91dc8289",
-                description: '"\'Three poems" published in Poetry Ireland.',
+                description:
+                    '"\'Three poems" published in <i>Poetry Ireland</i>.',
                 date: "April",
                 type: "personal",
             },
@@ -632,7 +635,7 @@ export const timelineData = [
                 id: "dd572afa-b4f4-5c93-9434-32c71b7b3253",
                 type: "personal",
                 decription:
-                    "Samuel Beckett begins translations for Sélection, the French edition of The Reader's Digest.",
+                    "Samuel Beckett begins translations for Sélection, the French edition of <i>The Reader's Digest</i>.",
                 date: "before 1 June",
             },
             {
@@ -663,14 +666,14 @@ export const timelineData = [
             {
                 id: "696e73a1-0561-5c95-929d-be3831a9ca4b",
                 description:
-                    "Beckett sends an extract from Watt to John Ryan, editor of Envoy.",
+                    "Beckett sends an extract from <i>Watt</i> to John Ryan, editor of <i>Envoy</i>.",
                 date: "20 October",
                 type: "personal",
             },
             {
                 id: "f65018fe-34a9-572f-9829-60ecad9efd4d",
                 description:
-                    '"Three Dialogues" published in Transition Forty-Nine, no. 5.',
+                    '"Three Dialogues" published in <i>Transition Forty-Nine</i>, no. 5.',
                 date: "10 December",
                 type: "personal",
             },
@@ -682,20 +685,21 @@ export const timelineData = [
             {
                 id: "f135bd9e-9194-5b17-8965-c23419a0c92c",
                 description:
-                    "Samuel Beckett commissioned by UNESCO to do the English translation of the Anthology of Mexican Poetry edited by Octavio Paz.",
+                    "Samuel Beckett commissioned by UNESCO to do the English translation of the <i>Anthology of Mexican Poetry</i> edited by Octavio Paz.",
                 date: "January",
                 type: "personal",
             },
             {
                 id: "d5065c0e-2375-50fb-ae27-cb915a4660e1",
                 description:
-                    '"An extract from Watt" published in Envoy (Dublin).',
+                    '"An extract from <i>Watt</i>" published in <i>Envoy</i> (Dublin).',
                 date: "January",
                 type: "personal",
             },
             {
                 id: "4d61cce9-d0dd-5af7-bd45-a741b089843d",
-                description: "Samuel Beckett finishes a draft of L'Innommable.",
+                description:
+                    "Samuel Beckett finishes a draft of <i>L'Innommable</i>.",
                 date: "January",
                 type: "personal",
             },
@@ -709,7 +713,7 @@ export const timelineData = [
             {
                 id: "7100be2a-178b-5c3d-9e66-169296fa7f4d",
                 description:
-                    "Samuel Beckett revises Ralph Mannheim's translation of George Duthuit's Les Fauves.",
+                    "Samuel Beckett revises Ralph Mannheim's translation of George Duthuit's <i>Les Fauves</i>.",
                 date: "March",
                 type: "personal",
             },
@@ -769,42 +773,42 @@ export const timelineData = [
             {
                 id: "7387afe1-58c9-5b19-bccc-dacb2f24eb7d",
                 description:
-                    "Extract from Malone meurt accepted by Georges Lambrichs for publication in Editions de Minuit's journal 84: Nouvelle Revue Littéraire.",
+                    "Extract from <i>Malone meurt</i> accepted by Georges Lambrichs for publication in Editions de Minuit's journal <i>84: Nouvelle Revue Littéraire</i>.",
                 date: "4 October",
                 type: "personal",
             },
             {
                 id: "5ad9a290-607e-51c4-8e79-95446e3f5609",
                 description:
-                    "Suzanne Deschevaux-Dumesnil brings Molloy to Georges Lambrichs at Editions de Minuit.",
+                    "Suzanne Deschevaux-Dumesnil brings <i>Molloy</i> to Georges Lambrichs at Editions de Minuit.",
                 date: "6 October",
                 type: "personal",
             },
             {
                 id: "9f95608b-cafe-5594-b6f2-72332a19d7eb",
                 description:
-                    "Jérôme Lindon reads Molloy and writes to Suzanne Deschevaux-Dumesnil that Editions de Minuit will publish the novel.",
+                    "Jérôme Lindon reads <i>Molloy</i> and writes to Suzanne Deschevaux-Dumesnil that Editions de Minuit will publish the novel.",
                 date: "before mid-October",
                 type: "personal",
             },
             {
                 id: "a3e897a5-513c-5d62-8450-bef8affc0c49",
                 description:
-                    'Extracts from Molloy and Malone meurt, translated by Samuel Beckett, are published in Transition Fifty, no. 6 as "Two Fragments."',
+                    'Extracts from <i>Molloy</i> and <i>Malone meurt</i>, translated by Samuel Beckett, are published in Transition Fifty, no. 6 as "Two Fragments."',
                 date: "20 October",
                 type: "personal",
             },
             {
                 id: "fbc42a01-e4e5-5899-a707-3257f2ecd0f9",
                 description:
-                    "Suzanne Deschevaux-Dumensil returns the signed contracts to Editions de Minuit for publication of the three novels Molloy, Malone meurt, L'Innommable.",
+                    "Suzanne Deschevaux-Dumensil returns the signed contracts to Editions de Minuit for publication of the three novels <i>Molloy</i>, <i>Malone meurt</i>, <i>L'Innommable</i>.",
                 date: "15 November",
                 type: "personal",
             },
             {
                 id: "89bb810a-d06b-58fa-b74e-d9366f887203",
                 description:
-                    '"Malone s\'en conte," an extract from Malone meurt, published in 84: Nouvelle Revue Littéraire.',
+                    '"Malone s\'en conte," an extract from <i>Malone meurt</i>, published in <i>84: Nouvelle Revue Littéraire</i>.',
                 date: "December",
                 type: "personal",
             },
@@ -821,7 +825,8 @@ export const timelineData = [
         events: [
             {
                 id: "65a2c165-e820-5411-b90e-2e8ba0c1a886",
-                description: "Samuel Beckett receives proofs for Molloy.",
+                description:
+                    "Samuel Beckett receives proofs for <i>Molloy</i>.",
                 date: "22 January",
                 type: "personal",
             },
@@ -845,7 +850,7 @@ export const timelineData = [
             },
             {
                 id: "192b6223-6150-5171-96d3-e025e8f54641",
-                description: "Molloy published by Editions de Minuit.",
+                description: "<i>Molloy</i> published by Editions de Minuit.",
                 date: "12 March",
                 type: "personal",
             },
@@ -858,7 +863,7 @@ export const timelineData = [
             {
                 id: "787565ba-0a3e-5996-9044-cf7d0033ffe3",
                 description:
-                    "First review of Molloy by Maurice Nadeau in Combat",
+                    "First review of <i>Molloy</i> by Maurice Nadeau in Combat",
                 date: "12 April",
                 type: "personal",
             },
@@ -878,7 +883,7 @@ export const timelineData = [
             {
                 id: "293bba06-8159-5845-9151-ce798c86ad1f",
                 description:
-                    "Georges Bataille publishes an essay on Molloy in Critique.",
+                    "Georges Bataille publishes an essay on <i>Molloy</i> in <i>Critique</i>.",
                 date: "May",
                 type: "personal",
             },
@@ -891,26 +896,27 @@ export const timelineData = [
             {
                 id: "245252c6-7eff-507b-b4a8-957285e80683",
                 description:
-                    "Charles Bensoussan wishes to produce Eleutheria, but Samuel Beckett is uneasy about the play.",
+                    "Charles Bensoussan wishes to produce <i>Eleutheria</i>, but Samuel Beckett is uneasy about the play.",
                 date: "25 May",
                 type: "personal",
             },
             {
                 id: "6dcc5213-5f31-5326-be25-9c6a04a33354",
-                description: "Molloy nominated for the Prix des Critiques.",
+                description:
+                    "<i>Molloy</i> nominated for the Prix des Critiques.",
                 date: "29 May",
                 type: "personal",
             },
             {
                 id: "86ab7ca8-7e27-5a8b-9939-ce58ee0f215b",
-                description: "Samuel Beckett is revising Malone meurt.",
+                description: "Samuel Beckett is revising <i>Malone meurt</i>.",
                 date: "9 June",
                 type: "personal",
             },
             {
                 id: "78adca99-6c94-5eef-8274-9b63433a71c7",
                 description:
-                    "Offers an extract from Malone meurt or from En attendant Godot to Les Temps Modernes in response to a request by Simone de Beauvoir.",
+                    "Offers an extract from <i>Malone meurt</i> or from <i>En attendant Godot</i> to <i>Les Temps Modernes</i> in response to a request by Simone de Beauvoir.",
                 date: "25 June",
                 type: "personal",
             },
@@ -922,14 +928,15 @@ export const timelineData = [
             },
             {
                 id: "05da43ce-cb08-552a-aea6-8a9ca138d867",
-                description: "Delivers Malone meurt to Editions de Minuit. ",
+                description:
+                    "Delivers <i>Malone meurt</i> to Editions de Minuit. ",
                 date: "4 July",
                 type: "personal",
             },
             {
                 id: "9790dde6-6b2a-5545-b6ca-0dd6d6621536",
                 description:
-                    'Sends "Texte pour rien, V" ("torn off the placenta of L\'Innommable") to Jean Wahl for Deucalion.',
+                    'Sends "Texte pour rien, V" ("torn off the placenta of <i>L\'Innommable</i>") to Jean Wahl for Deucalion.',
                 date: "8 July",
                 type: "personal",
             },
@@ -942,7 +949,7 @@ export const timelineData = [
             {
                 id: "5b91577e-05a3-5d93-ad84-c160ec88bf93",
                 description:
-                    "Has corrected proofs of extract from Malone meurt in Les Temps Modernes.",
+                    "Has corrected proofs of extract from <i>Malone meurt</i> in <i>Les Temps Modernes</i>.",
                 date: "by 26 July",
                 type: "personal",
             },
@@ -961,7 +968,7 @@ export const timelineData = [
             {
                 id: "a36bee1a-52e9-5080-9063-6def2a100db3",
                 description:
-                    '"Quel malheur . . . ," an extract from Malone meurt, published in Les Temps Modernes.',
+                    '"Quel malheur . . . ," an extract from <i>Malone meurt</i>, published in <i>Les Temps Modernes</i>.',
                 date: "September",
                 type: "personal",
             },
@@ -981,7 +988,7 @@ export const timelineData = [
             },
             {
                 id: "a994ae62-5558-519c-83fb-be7761e143f9",
-                description: "Publication of Malone meurt.",
+                description: "Publication of <i>Malone meurt</i>.",
                 date: "November",
                 type: "personal",
             },
@@ -994,7 +1001,8 @@ export const timelineData = [
             },
             {
                 id: "cdd07bd7-c36c-5e14-82ff-f508703a7373",
-                description: "Extract from Watt published in Irish Writing.",
+                description:
+                    "Extract from <i>Watt</i> published in <i>Irish Writing</i>.",
                 date: "December",
                 type: "personal",
             },
@@ -1013,14 +1021,14 @@ export const timelineData = [
             {
                 id: "20cc2194-8698-5e6c-a778-89231f072c39",
                 description:
-                    "Director Roger Blin seeks a Paris theatre for En attendant Godot.",
+                    "Director Roger Blin seeks a Paris theatre for <i>En attendant Godot</i>.",
                 date: "January",
                 type: "personal",
             },
             {
                 id: "6353dde3-b93b-5f28-94a3-3cbf1639f32d",
                 description:
-                    "An excerpt of En attendant Godot recorded on 6 February for broadcast on French radio,",
+                    "An excerpt of <i>En attendant Godot</i> recorded on 6 February for broadcast on French radio,",
                 date: "17 February.	6 February",
                 type: "personal",
             },
@@ -1041,7 +1049,7 @@ export const timelineData = [
             {
                 id: "fa5e4777-0a35-5688-967c-c00c5babd70e",
                 description:
-                    'A subvention "pour aider le montage" awarded for the production of En attendant Godot.',
+                    'A subvention "pour aider le montage" awarded for the production of <i>En attendant Godot</i>.',
                 date: "26 February",
                 type: "personal",
             },
@@ -1062,21 +1070,21 @@ export const timelineData = [
             {
                 id: "7d77ea5a-0158-557f-b98d-f48e304136a4",
                 description:
-                    "En attendant Godot in rehearsal: autumn production anticipated.",
+                    "<i>En attendant Godot</i> in rehearsal: autumn production anticipated.",
                 date: "2 June",
                 type: "personal",
             },
             {
                 id: "fa8bf0a5-c26e-568b-a7c9-34200dd3783d",
                 description:
-                    "Agreement signed with France Guy, Théâtre de Poche, to qualify for subvention payment for En attendant Godot.",
+                    "Agreement signed with France Guy, Théâtre de Poche, to qualify for subvention payment for <i>En attendant Godot</i>.",
                 date: "23 July",
                 type: "personal",
             },
             {
                 id: "d945f2e2-cf46-5c9b-b484-ca2d864fb335",
                 description:
-                    "Merlin interested in publishing a work by Samuel Beckett.",
+                    "<i>Merlin</i> interested in publishing a work by Samuel Beckett.",
                 date: "12 August",
                 type: "personal",
             },
@@ -1095,7 +1103,7 @@ export const timelineData = [
             },
             {
                 id: "d82cc63a-280b-52c9-a0b7-62d5e8dd573d",
-                description: "Publication of En attendant Godot.",
+                description: "Publication of <i>En attendant Godot</i>.",
                 date: "17 October",
                 type: "personal",
             },
@@ -1115,19 +1123,20 @@ export const timelineData = [
             {
                 id: "48967fb2-4db2-5558-a282-6003d0d14139",
                 description:
-                    "Subsequent to broken agreement with the Théâtre de Poche, Samuel Beckett signs contract with Théâtre de Babylone for production of En attendant Godot.",
+                    "Subsequent to broken agreement with the Théâtre de Poche, Samuel Beckett signs contract with Théâtre de Babylone for production of <i>En attendant Godot</i>.",
                 date: "2 November",
                 type: "personal",
             },
             {
                 id: "1ce16089-5b05-57c8-b44c-f09abc70ab4b",
-                description: "Rehearsals of En attendant Godot begin.",
+                description: "Rehearsals of <i>En attendant Godot</i> begin.",
                 date: "13 November",
                 type: "personal",
             },
             {
                 id: "b9d81ff6-6fa0-5e34-8e08-a83c2c601876",
-                description: '"Extract from Watt" published in Merlin.',
+                description:
+                    '"Extract from <i>Watt</i>" published in <i>Merlin</i>.',
                 date: "15 December",
                 type: "personal",
             },
@@ -1145,7 +1154,7 @@ export const timelineData = [
             {
                 id: "1a0b53e9-65c3-520c-816a-211545459b62",
                 description:
-                    "Premiere of En attendant Godot, Théâtre de Babylone.",
+                    "Premiere of <i>En attendant Godot</i>, Théâtre de Babylone.",
                 date: "5 January",
                 type: "personal",
             },
@@ -1159,28 +1168,28 @@ export const timelineData = [
             {
                 id: "ffbb7991-768f-5edb-83a5-7c173a1d8154",
                 description:
-                    "Boisterous spectators interrupt performance of En attendant Godot.",
+                    "Boisterous spectators interrupt performance of <i>En attendant Godot</i>.",
                 date: "31 January",
                 type: "personal",
             },
             {
                 id: "38ea3c0b-9849-5013-bd65-8c58bd0bf6c4",
                 description:
-                    '"Mahood," an excerpt from L\'Innommable, published in the Nouvelle Revue Française with unauthorized cuts.',
+                    '"Mahood," an excerpt from <i>L\'Innommable</i>, published in the <i>Nouvelle Revue Française</i> with unauthorized cuts.',
                 date: "February",
                 type: "personal",
             },
             {
                 id: "d3c6c507-1184-5995-8504-6ad63dbff649",
                 description:
-                    "Alain Robbe-Grillet publishes essay on Samuel Beckett's work in Critique.",
+                    "Alain Robbe-Grillet publishes essay on Samuel Beckett's work in <i>Critique</i>.",
                 date: "February",
                 type: "personal",
             },
             {
                 id: "ca4960e2-5f25-5256-898a-50134bd1a443",
                 description:
-                    "Samuel Beckett reads draft of Elmar Tophoven's German translation, Warten auf Godot.",
+                    "Samuel Beckett reads draft of Elmar Tophoven's German translation, <i>Warten auf Godot</i>.",
                 date: "by 19 February",
                 type: "personal",
             },
@@ -1193,14 +1202,14 @@ export const timelineData = [
             {
                 id: "dae8dc96-51fd-54ec-8701-489394d3d61a",
                 description:
-                    'Note of apology published in the Nouvelle Revue Française for cuts made to Samuel Beckett\'s "Mahood."',
+                    'Note of apology published in the <i>Nouvelle Revue Française</i> for cuts made to Samuel Beckett\'s "Mahood."',
                 date: "April",
                 type: "personal",
             },
             {
                 id: "6ada8488-65cd-551b-b8ca-3337c25a221c",
                 description:
-                    '"Trois Textes pour rien [III, VI, X]" published in Les Lettres Nouvelles.',
+                    '"Trois Textes pour rien [III, VI, X]" published in <i>Les Lettres Nouvelles</i>.',
                 date: "May",
                 type: "personal",
             },
@@ -1214,27 +1223,27 @@ export const timelineData = [
             {
                 id: "61e5a82b-7808-5520-a80b-ef5156c8fc22",
                 description:
-                    "Offer received from Mrs. Garson Kanin and Thornton Wilder for an English translation and production in the United States of En attendant Godot.",
+                    "Offer received from Mrs. Garson Kanin and Thornton Wilder for an English translation and production in the United States of <i>En attendant Godot</i>.",
                 date: "15 May",
                 type: "personal",
             },
             {
                 id: "aeb5cb47-915a-5ecc-b8ec-db35bb9f22ef",
-                description: "Publication of L'Innommable.",
+                description: "Publication of <i>L'Innommable</i>.",
                 date: "20 May",
                 type: "personal",
             },
             {
                 id: "58bcc58b-b4a7-5bf6-8f62-be6c596ec35f",
                 description:
-                    "Barney Rosset, Grove Press, offers to publish English translations of En attendant Godot, Molloy, Malone meurt, and takes an option for L'Innommable.",
+                    "Barney Rosset, Grove Press, offers to publish English translations of <i>En attendant Godot</i>, <i>Molloy</i>, <i>Malone meurt</i>, and takes an option for <i>L'Innommable</i>.",
                 date: "before 22 May",
                 type: "personal",
             },
             {
                 id: "308a7dc7-4f6f-50f3-add7-ad8a6520feb0",
                 description:
-                    '"Texte pour rien, XI" published in Arts-Spectacles.',
+                    '"Texte pour rien, XI" published in <i>Arts-Spectacles</i>.',
                 date: "3 July",
                 type: "personal",
             },
@@ -1248,28 +1257,28 @@ export const timelineData = [
             {
                 id: "6daf8e5b-48a9-590a-9d4a-afb11c53679d",
                 description:
-                    "Samuel Beckett working in Paris with Patrick Bowles on the English translation of Molloy.",
+                    "Samuel Beckett working in Paris with Patrick Bowles on the English translation of <i>Molloy</i>.",
                 date: "by 27 July",
                 type: "personal",
             },
             {
                 id: "c164c68f-91d0-5628-826c-d45c710ef0da",
                 description:
-                    "Imprint date of Watt, Collection Merlin, Olympia Press.",
+                    "Imprint date of <i>Watt</i>, Collection <i>Merlin</i>, Olympia Press.",
                 date: "31 August",
                 type: "personal",
             },
             {
                 id: "bbf1acca-aec9-55cc-8b1d-c5a06d8e98a7",
                 description:
-                    "Reprint of En attendant Godot with cuts and changes made for performance.",
+                    "Reprint of <i>En attendant Godot</i> with cuts and changes made for performance.",
                 date: "September",
                 type: "personal",
             },
             {
                 id: "11d22ab9-726a-55fa-8002-ae6be6ee2e52",
                 description:
-                    "Nadeau publishes essay on L'Innommable in Les Lettres Nouvelles.",
+                    "Nadeau publishes essay on <i>L'Innommable</i> in <i>Les Lettres Nouvelles</i>.",
                 date: "September",
                 type: "personal",
             },
@@ -1289,49 +1298,49 @@ export const timelineData = [
             {
                 id: "73dc0458-c68e-5d80-9bfb-222c19c51508",
                 description:
-                    "Samuel Beckett attends premiere of Warten auf Godot, Schauspielhaus, Berlin.",
+                    "Samuel Beckett attends premiere of <i>Warten auf Godot</i>, Schauspielhaus, Berlin.",
                 date: "8 September",
                 type: "personal",
             },
             {
                 id: "3ac3ea12-547d-5a48-b4ff-6e3e66667616",
                 description:
-                    '"Extract from Molloy," translated by Patrick Bowles, published in Merlin.',
+                    '"Extract from <i>Molloy</i>," translated by Patrick Bowles, published in <i>Merlin</i>.',
                 date: "15 September",
                 type: "personal",
             },
             {
                 id: "9878baee-aa36-52e0-b97e-2f571be9fd5a",
                 description:
-                    "Reprise of En attendant Godot, Théâtre de Babylone.",
+                    "Reprise of <i>En attendant Godot</i>, Théâtre de Babylone.",
                 date: "25 September",
                 type: "personal",
             },
             {
                 id: "b27e4077-ee85-5e06-aace-1a8bdd44e777",
                 description:
-                    "Samuel Beckett works on French translation of Watt with Daniel Mauroc.",
+                    "Samuel Beckett works on French translation of <i>Watt</i> with Daniel Mauroc.",
                 date: "by 31 October",
                 type: "personal",
             },
             {
                 id: "10aca531-9f08-5af0-a2c8-da2e89fb3acf",
                 description:
-                    '"Texte pour rien, XIII" published in Le Disque Vert.',
+                    '"Texte pour rien, XIII" published in <i>Le Disque Vert</i>.',
                 date: "November",
                 type: "personal",
             },
             {
                 id: "749e1f96-7329-5e5c-abf4-22a64eb8db61",
                 description:
-                    "Tour of the Théâtre de Babylone production of En attendant Godot: Germany, Italy, and France.",
+                    "Tour of the Théâtre de Babylone production of <i>En attendant Godot</i>: Germany, Italy, and France.",
                 date: "16 November - 12 December",
                 type: "personal",
             },
             {
                 id: "d413446b-0478-5424-9bb0-fa58b24687e3",
                 description:
-                    "Opening performance of Godot, by prisoners, in Lüttringhausen, in a German translation by one of their number.",
+                    "Opening performance of <i>Godot</i>, by prisoners, in Lüttringhausen, in a German translation by one of their number.",
                 date: "29 November",
                 type: "personal",
             },
@@ -1356,14 +1365,14 @@ export const timelineData = [
             {
                 id: "0780edeb-98ae-520a-8ae8-b3e71163b859",
                 description:
-                    "Correcting proofs of Waiting for Godot for Grove Press. Reviewing Trino Martínez Trives's translation Esperando a Godot. Refuses to allow Editions de Minuit to publish Mercier et Camier.",
+                    "Correcting proofs of <i>Waiting for Godot</i> for Grove Press. Reviewing Trino Martínez Trives's translation <i>Esperando a Godot</i>. Refuses to allow Editions de Minuit to publish <i>Mercier et Camier</i>.",
                 date: "20 January",
                 type: "personal",
             },
             {
                 id: "f7652d73-c52c-57e8-945a-a470e978d07f",
                 description:
-                    "Reviews German translation of Molloy by translator Erich Franzen in a series of letters.",
+                    "Reviews German translation of <i>Molloy</i> by translator Erich Franzen in a series of letters.",
                 date: "23 January - 17 February",
                 type: "personal",
             },
@@ -1377,20 +1386,21 @@ export const timelineData = [
             {
                 id: "047e3c32-7370-563e-a52d-8646b3025387",
                 description:
-                    "Blin's production of Warten auf Godot opens in the Schauspielhaus, Zurich.",
+                    "Blin's production of <i>Warten auf Godot</i> opens in the Schauspielhaus, Zurich.",
                 date: "25 February",
                 type: "personal",
             },
             {
                 id: "6c98c942-abe0-5e63-8cea-f250353b3a76",
-                description: '"Extract from Molloy" published in Paris Review.',
+                description:
+                    '"Extract from <i>Molloy</i>" published in Paris Review.',
                 date: "March",
                 type: "personal",
             },
             {
                 id: "e2ec6f28-5a7e-5ad3-a1ae-cf91e6a8e774",
                 description:
-                    "Samuel Beckett asks Jacques Putman, Georges Duthuit, and Pierre Schneider to contribute short essays on the painting of Jack B. Yeats for Les Lettres Nouvelles.",
+                    "Samuel Beckett asks Jacques Putman, Georges Duthuit, and Pierre Schneider to contribute short essays on the painting of Jack B. Yeats for <i>Les Lettres Nouvelles</i>.",
                 date: "March",
                 type: "personal",
             },
@@ -1404,21 +1414,21 @@ export const timelineData = [
             {
                 id: "c154714c-dfc1-5615-9981-f4f355977445",
                 description:
-                    '"Molloy," an excerpt from Molloy, published in New World Writing.',
+                    '"Molloy," an excerpt from <i>Molloy</i>, published in <i>New World Writing</i>.',
                 date: "April",
                 type: "personal",
             },
             {
                 id: "e521d421-f375-519d-91cc-72a359fab648",
                 description:
-                    'Samuel Beckett\'s "Hommage à Jack B Yeats" published in Les Lettres Nouvelles.',
+                    'Samuel Beckett\'s "Hommage à Jack B Yeats" published in <i>Les Lettres Nouvelles</i>.',
                 date: "April",
                 type: "personal",
             },
             {
                 id: "7560db46-d8a5-587b-b17b-2b132f0d1347",
                 description:
-                    "Samuel Beckett responds to Lord Chamberlain's Office censorship of text of Waiting for Godot.",
+                    "Samuel Beckett responds to Lord Chamberlain's Office censorship of text of <i>Waiting for Godot</i>.",
                 date: "14 April",
                 type: "personal",
             },
@@ -1431,7 +1441,7 @@ export const timelineData = [
             {
                 id: "9b02a40b-347d-54cb-9403-aecc5d92d94b",
                 description:
-                    "Two sonnets by Miguel de Guevara, translated by Samuel Beckett for the Anthology of Mexican Poetry, published in Hermathena.",
+                    "Two sonnets by Miguel de Guevara, translated by Samuel Beckett for the <i>Anthology of Mexican Poetry</i>, published in Hermathena.",
                 date: "May",
                 type: "personal",
             },
@@ -1452,35 +1462,35 @@ export const timelineData = [
             {
                 id: "510fc445-0a1f-5321-89de-c7cae2b12788",
                 description:
-                    "Objections of the Lord Chamberlain's Office to the text of Waiting for Godot resolved.",
+                    "Objections of the Lord Chamberlain's Office to the text of <i>Waiting for Godot</i> resolved.",
                 date: "23 June",
                 type: "personal",
             },
             {
                 id: "63fe3dd9-4fab-5a5e-a479-157225786a0f",
                 description:
-                    "Samuel Beckett has begun the English translation of Malone meurt.",
+                    "Samuel Beckett has begun the English translation of <i>Malone meurt</i>.",
                 date: "12 July",
                 type: "personal",
             },
             {
                 id: "2187a6fc-58a0-5197-a6d7-a266a9165899",
                 description:
-                    "Waiting for Godot, translated by the author, published by Grove Press.",
+                    "<i>Waiting for Godot</i>, translated by the author, published by Grove Press.",
                 date: "end of August",
                 type: "personal",
             },
             {
                 id: "1bba601b-ca23-5fd5-839a-44d0134bd3b4",
                 description:
-                    '"The End," translated by Richard Seaver in collaboration with the author, published in Merlin.',
+                    '"The End," translated by Richard Seaver in collaboration with the author, published in <i>Merlin</i>.',
                 date: "Summer-Autumn",
                 type: "personal",
             },
             {
                 id: "3b238ec7-c325-5868-8029-333279da1063",
                 description:
-                    "Samuel Beckett correcting proofs of Pablo Palant's translation of Esperando a Godot.",
+                    "Samuel Beckett correcting proofs of Pablo Palant's translation of <i>Esperando a Godot</i>.",
                 date: "7 September",
                 type: "personal",
             },
@@ -1530,7 +1540,7 @@ export const timelineData = [
             {
                 id: "c805b141-65e8-5e50-b681-5469e5158ba2",
                 description:
-                    "Samuel Beckett gives Patrick Bowles final text of translation of Molloy; Bowles sends to Rosset on 23 January.",
+                    "Samuel Beckett gives Patrick Bowles final text of translation of <i>Molloy</i>; Bowles sends to Rosset on 23 January.",
                 date: "13 January",
                 type: "personal",
             },
@@ -1543,28 +1553,28 @@ export const timelineData = [
             {
                 id: "ed45b393-7547-504e-85e1-18018fed6f2a",
                 description:
-                    "Molloy published in English by Collection Merlin, Olympia Press.",
+                    "<i>Molloy</i> published in English by Collection <i>Merlin</i>, Olympia Press.",
                 date: "March",
                 type: "personal",
             },
             {
                 id: "8461e1a6-0b0a-5141-8a8a-fc3b59fb8743",
                 description:
-                    "Opening of Blin's production of Wachten op Godot, Toneelgroep Theater, Arnhem.",
+                    "Opening of Blin's production of <i>Wachten op Godot</i>, Toneelgroep Theater, Arnhem.",
                 date: "6 March",
                 type: "personal",
             },
             {
                 id: "a74f340d-b770-58de-a767-3ac59d1efa28",
                 description:
-                    "Samuel Beckett completes draft of play eventually entitled Fin de partie.",
+                    "Samuel Beckett completes draft of play eventually entitled <i>Fin de partie</i>.",
                 date: "13 March",
                 type: "personal",
             },
             {
                 id: "f351ce3f-cda3-5410-b436-a92244124149",
                 description:
-                    "Delivers manuscript of Nouvelles et Textes pour rien to Editions de Minuit.",
+                    "Delivers manuscript of <i>Nouvelles et Textes pour rien</i> to Editions de Minuit.",
                 date: "27 March",
                 type: "personal",
             },
@@ -1584,14 +1594,14 @@ export const timelineData = [
             {
                 id: "caa5381f-6a96-5a2f-b904-c084dd92025f",
                 description:
-                    '"Deux textes pour rien [I, IX]" published in Monde Nouveau/Paru.',
+                    '"Deux textes pour rien [I, IX]" published in <i>Monde Nouveau/Paru</i>.',
                 date: "May-June",
                 type: "personal",
             },
             {
                 id: "5494163d-03a9-554b-a5c1-b24f864881c7",
                 description:
-                    "Esperando a Godot performed in Madrid, despite ban on publicity and public performance.",
+                    "<i>Esperando a Godot</i> performed in Madrid, despite ban on publicity and public performance.",
                 date: "28 May",
                 type: "personal",
             },
@@ -1611,48 +1621,48 @@ export const timelineData = [
             {
                 id: "b7955648-3538-5124-bb0e-4699ab836879",
                 description:
-                    "Attends opening of Alan Schneider's production of Thornton Wilder's The Skin of Our Teeth, Théâtre Sarah Bernhardt, Paris.",
+                    "Attends opening of Alan Schneider's production of Thornton Wilder's <i>The Skin of Our Teeth</i>, Théâtre Sarah Bernhardt, Paris.",
                 date: "28 June",
                 type: "personal",
             },
             {
                 id: "ff639200-9df0-5c80-9ed4-c691a94e670a",
-                description: "Molloy published by Grove Press.",
+                description: "<i>Molloy</i> published by Grove Press.",
                 date: "August",
                 type: "personal",
             },
             {
                 id: "8b98564b-c5c6-5e28-a6b1-9ff6fbd369cb",
                 description:
-                    "Opening of Waiting for Godot, Arts Theatre, London, directed by Peter Hall.",
+                    "Opening of <i>Waiting for Godot</i>, Arts Theatre, London, directed by Peter Hall.",
                 date: "3 August",
                 type: "personal",
             },
             {
                 id: "8f746e72-a0d9-57d0-af00-e8fd1525e6e8",
                 description:
-                    "Samuel Beckett completes draft of his translation of Malone meurt. Has written a mime scenario for Deryk Mendel.",
+                    "Samuel Beckett completes draft of his translation of <i>Malone meurt</i>. Has written a mime scenario for Deryk Mendel.",
                 date: "18 August",
                 type: "personal",
             },
             {
                 id: "07b7ded1-6a6f-51e0-bd84-fb890186aae5",
                 description:
-                    "Extract from Watt broadcast on the BBC Third Programme.",
+                    "Extract from <i>Watt</i> broadcast on the BBC Third Programme.",
                 date: "7 September",
                 type: "personal",
             },
             {
                 id: "f7982222-6f7e-57d9-98aa-246216759ea6",
                 description:
-                    "Waiting for Godot transfers to the Criterion Theatre, London.",
+                    "<i>Waiting for Godot</i> transfers to the Criterion Theatre, London.",
                 date: "12 September",
                 type: "personal",
             },
             {
                 id: "9e6c8780-006c-581e-8a58-d237430203b9",
                 description:
-                    '"Trois poèmes" ("Accul," "Mort de A.D.," and "vive morte") published in Cahiers des Saisons, a Minuit journal previously entitled 84: Nouvelle Revue Littéraire.',
+                    '"Trois poèmes" ("Accul," "Mort de A.D.," and "vive morte") published in <i>Cahiers des Saisons</i>, a Minuit journal previously entitled <i>84: Nouvelle Revue Littéraire</i>.',
                 date: "October",
                 type: "personal",
             },
@@ -1667,55 +1677,56 @@ export const timelineData = [
             {
                 id: "763e24e4-f194-5ca3-bc97-5b4032045cef",
                 description:
-                    "Opening of Waiting for Godot at the Pike Theatre, Dublin.",
+                    "Opening of <i>Waiting for Godot</i> at the Pike Theatre, Dublin.",
                 date: "28 October",
                 type: "personal",
             },
             {
                 id: "e459dbf8-a416-5694-87b3-e7f151caaa13",
                 description:
-                    '"Henri Hayden, homme-peintre" published in Arts-documents (Geneva).',
+                    '"Henri Hayden, homme-peintre" published in <i>Arts-documents</i> (Geneva).',
                 date: "November",
                 type: "personal",
             },
             {
                 id: "f1bd676a-5800-5260-9311-c36d50d8169a",
                 description:
-                    "Samuel Beckett meets Donald Albery, London producer of Waiting for Godot, in Paris.",
+                    "Samuel Beckett meets Donald Albery, London producer of <i>Waiting for Godot</i>, in Paris.",
                 date: "3 November",
                 type: "personal",
             },
             {
                 id: "c2fbd348-4b3b-525f-b4ad-d99d6e2a4565",
                 description:
-                    "Composer John Beckett working in Paris with Deryk Mendel on music for a mime (Act Without Words I).",
+                    "Composer John Beckett working in Paris with Deryk Mendel on music for a mime (<i>Act Without Words I</i>).",
                 date: "26 November",
                 type: "personal",
             },
             {
                 id: "96f14e16-1a2f-5e38-a94a-6aef1f5f9fe6",
-                description: "Imprint date of Nouvelles et Textes pour rien.",
+                description:
+                    "Imprint date of <i>Nouvelles et Textes pour rien</i>.",
                 date: "15 November",
                 type: "personal",
             },
             {
                 id: "f8205159-b75e-5ecb-944d-7b6caf106eb7",
                 description:
-                    "Samuel Beckett discusses Waiting for Godot with Alan Schneider in Paris.",
+                    "Samuel Beckett discusses <i>Waiting for Godot</i> with Alan Schneider in Paris.",
                 date: "from 26 November",
                 type: "personal",
             },
             {
                 id: "4a889c26-fe15-5980-93ce-a91a381ab5b3",
                 description:
-                    "Samuel Beckett and Schneider attend several performances of London production of Waiting for Godot. Samuel Beckett meets German actress Elizabeth Bergner in London.",
+                    "Samuel Beckett and Schneider attend several performances of London production of <i>Waiting for Godot</i>. Samuel Beckett meets German actress Elizabeth Bergner in London.",
                 date: "early December",
                 type: "personal",
             },
             {
                 id: "16998334-f5db-52b6-a52a-e7051868e508",
                 description:
-                    "Samuel Beckett attends 100th performance of Waiting for Godot in London.",
+                    "Samuel Beckett attends 100th performance of <i>Waiting for Godot</i> in London.",
                 date: "8 December",
                 type: "personal",
             },
@@ -1727,13 +1738,13 @@ export const timelineData = [
             {
                 id: "a0100873-42b1-55ac-a7af-83cce09f7b6f",
                 description:
-                    "US opening of Waiting for Godot, Coconut Grove Playhouse, Miami, directed by Alan Schneider.",
+                    "US opening of <i>Waiting for Godot</i>, Coconut Grove Playhouse, Miami, directed by Alan Schneider.",
                 date: "3 January",
                 type: "personal",
             },
             {
                 id: "48b50af6-ef06-5fa9-bb82-d21612cce633",
-                description: "All editions of Molloy banned in Ireland.",
+                description: "All editions of <i>Molloy</i> banned in Ireland.",
                 date: "20 January",
                 type: "personal",
             },
@@ -1747,14 +1758,14 @@ export const timelineData = [
             {
                 id: "68f369ab-655c-5223-a510-53538e115b02",
                 description:
-                    "Waiting for Godot published by Faber and Faber, in expurgated version.",
+                    "<i>Waiting for Godot</i> published by Faber and Faber, in expurgated version.",
                 date: "10 February",
                 type: "personal",
             },
             {
                 id: "8633749f-5ff7-57b0-a3b9-ad5569ff9743",
                 description:
-                    "Samuel Beckett begins translation of L'Innommable.",
+                    "Samuel Beckett begins translation of <i>L'Innommable</i>.",
                 date: "27 February",
                 type: "personal",
             },
@@ -1773,21 +1784,21 @@ export const timelineData = [
             {
                 id: "58c362af-8fd3-5791-8b9d-782110cb9e07",
                 description:
-                    "Extract from Malone Dies published in Irish Writing.",
+                    "Extract from <i>Malone Dies</i> published in <i>Irish Writing</i>.",
                 date: "April",
                 type: "personal",
             },
             {
                 id: "6f9caa82-cf58-502b-9ef1-8d5a101b2ab6",
                 description:
-                    "New York opening of Waiting for Godot at the John Golden Theatre, directed by Herbert Bergdorf.",
+                    "New York opening of <i>Waiting for Godot</i> at the John Golden Theatre, directed by Herbert Bergdorf.",
                 date: "19 April",
                 type: "personal",
             },
             {
                 id: "c3cfa174-86a0-5c3c-9da0-b7b964793867",
                 description:
-                    "Samuel Beckett revises Fin de partie for Marseille Festival of the Avant Garde in August.",
+                    "Samuel Beckett revises <i>Fin de partie</i> for Marseille Festival of the Avant Garde in August.",
                 date: "May-June",
                 type: "personal",
             },
@@ -1801,7 +1812,7 @@ export const timelineData = [
             {
                 id: "a78fecca-9698-523d-898b-121996e0ed00",
                 description:
-                    "Reprise of En attendant Godot, Théâtre Hébertot, Paris.",
+                    "Reprise of <i>En attendant Godot</i>, Théâtre Hébertot, Paris.",
                 date: "14 June - 23 September",
                 type: "personal",
             },
@@ -1822,7 +1833,7 @@ export const timelineData = [
             {
                 id: "1412f617-8db1-5990-89c9-045b9da08faa",
                 description:
-                    "Fin de partie and Acte sans paroles will not be produced in Marseille Festival.",
+                    "<i>Fin de partie</i> and <i>Acte sans paroles</i> will not be produced in Marseille Festival.",
                 date: "8 July",
                 type: "personal",
             },
@@ -1848,20 +1859,20 @@ export const timelineData = [
             {
                 id: "87d82dcd-a675-5c72-aae4-5518e0b95680",
                 description:
-                    '"Waiting for Godot" published in Theatre Arts (New York).',
+                    '"<i>Waiting for Godot</i>" published in Theatre Arts (New York).',
                 date: "August",
                 type: "personal",
             },
             {
                 id: "d67bc5ff-ab2d-5d39-94e6-13e49fffa778",
                 description:
-                    "Samuel Beckett meets Goddard Lieberson, director of Columbia Records, New York, who brings him test recording of Waiting for Godot.",
+                    "Samuel Beckett meets Goddard Lieberson, director of Columbia Records, New York, who brings him test recording of <i>Waiting for Godot</i>.",
                 date: "11 August",
                 type: "personal",
             },
             {
                 id: "3bf39cf0-a826-5565-8395-57af93e04cd8",
-                description: "Writing All That Fall for the BBC.",
+                description: "Writing <i>All That Fall</i> for the BBC.",
                 date: "23 August",
                 type: "personal",
             },
@@ -1874,27 +1885,28 @@ export const timelineData = [
             },
             {
                 id: "47a78014-aec5-52f1-9521-225a27b3bfa0",
-                description: "Extract from Watt, the BBC Third Programme.",
+                description:
+                    "Extract from <i>Watt</i>, the BBC Third Programme.",
                 date: "7 September",
                 type: "personal",
             },
             {
                 id: "d6be73ad-99ed-57d2-a4df-ba28cad7d84a",
                 description:
-                    "Samuel Beckett sends his first radio play All That Fall to the BBC.",
+                    "Samuel Beckett sends his first radio play <i>All That Fall</i> to the BBC.",
                 date: "27 September",
                 type: "personal",
             },
             {
                 id: "065a3292-c06c-5eb4-80ec-dbbfec5adb5f",
-                description: "Malone Dies published by Grove Press.",
+                description: "<i>Malone Dies</i> published by Grove Press.",
                 date: "October",
                 type: "personal",
             },
             {
                 id: "1d8e61ea-b058-5e06-83f8-f5c6975dfe33",
                 description:
-                    "Fin de Partie in preliminary rehearsal at the Théâtre de l'Oeuvre, Paris.",
+                    "<i>Fin de Partie</i> in preliminary rehearsal at the Théâtre de l'Oeuvre, Paris.",
                 date: "October",
                 type: "personal",
             },
@@ -1914,7 +1926,7 @@ export const timelineData = [
             {
                 id: "8e3429cf-0123-55c4-9d61-857f7612e587",
                 description:
-                    '"Yellow" from More Pricks Than Kicks published in New World Writing.',
+                    '"Yellow" from <i>More Pricks Than Kicks</i> published in <i>New World Writing</i>.',
                 date: "November",
                 type: "personal",
             },
@@ -1928,14 +1940,14 @@ export const timelineData = [
             {
                 id: "65cb9acd-37ad-5a4d-a947-f7ddbc54a186",
                 description:
-                    "John Calder Ltd proposes to publish Samuel Beckett's three novels (Molloy, Malone Dies, The Unnamable) in a single volume in England.",
+                    "John Calder Ltd proposes to publish Samuel Beckett's three novels (<i>Molloy</i>, <i>Malone Dies</i>, <i>The Unnamable</i>) in a single volume in England.",
                 date: "11 November",
                 type: "personal",
             },
             {
                 id: "e3b7c7a3-11ce-5a9b-bc6d-3334526a2196",
                 description:
-                    'Samuel Beckett "pre-rehearsing" Fin de partie with Jean Martin and Roger Blin for Théâtre de L\'Oeuvre, Paris.',
+                    'Samuel Beckett "pre-rehearsing" <i>Fin de partie</i> with Jean Martin and Roger Blin for Théâtre de L\'Oeuvre, Paris.',
                 date: "28 November",
                 type: "personal",
             },
@@ -1997,7 +2009,7 @@ export const timelineData = [
                 id: "208f3ebc-c219-557a-8f5b-ee4f75b3fa64",
                 date: "c. 11-15 February",
                 description:
-                    "In Paris, John Beckett and Deryk Mendel coordinate music and movements for <i>Acte sans paroles I</i>.",
+                    "In Paris, John Beckett and Deryk Mendel coordinate music and movements for <i>Acte sans paroles</i> I</i>.",
                 type: "personal",
                 additional: "none",
             },
@@ -2013,7 +2025,7 @@ export const timelineData = [
                 id: "94ae1a44-4eed-56f3-8d39-4a86382d4208",
                 date: "March",
                 description:
-                    "<i><i>Tous ceux qui tombent</i></i> published in Les Lettres Nouvelles. ",
+                    "<i>Tous ceux qui tombent</i> published in <i>Les Lettres Nouvelles</i>. ",
                 type: "personal",
                 additional:
                     "https://andalusiabooks.files.wordpress.com/2012/08/les-lettres-nouvelle_0002.jpg",
@@ -2095,7 +2107,7 @@ export const timelineData = [
                 id: "fb3bcf0f-f754-5bc4-82f6-07582388bf15",
                 date: "24 August",
                 description:
-                    "Beckett completes <i>Acte sans paroles II</i>, for Deryk Mendel.",
+                    "Beckett completes <i>Acte sans paroles</i> II</i>, for Deryk Mendel.",
                 type: "personal",
                 additional: "none",
             },
@@ -2232,7 +2244,7 @@ export const timelineData = [
                 id: "d0bf24dc-c995-5fcd-9967-380bb9f00e56",
                 date: "25 April",
                 description:
-                    "<i>Endgame</i>, followed by Act Without Words I, published by Faber and Faber.",
+                    "<i>Endgame</i>, followed by <i>Act Without Words I</i>, published by Faber and Faber.",
                 type: "personal",
                 additional: "image",
             },
@@ -2447,7 +2459,7 @@ export const timelineData = [
                 id: "0e4c7e32-e929-5649-ab44-130ae5c28a2f",
                 date: "4 March",
                 description:
-                    "Les Lettres Nouvelles publishes <i>La dernière bande</i>.",
+                    "<i>Les Lettres Nouvelles</i> publishes <i>La dernière bande</i>.",
                 type: "personal",
                 additional: "none",
             },
@@ -3610,7 +3622,8 @@ export const timelineData = [
             {
                 id: "ce7b8ff8-47b2-55fc-bfb9-3c27f107e48a",
                 date: "June",
-                description: "Comédie published in Les Lettres Nouvelles.",
+                description:
+                    "Comédie published in <i>Les Lettres Nouvelles</i>.",
                 type: "personal",
                 additional: "none",
             },

--- a/src/data/timelineData.js
+++ b/src/data/timelineData.js
@@ -473,9 +473,9 @@ export const timelineData = [
             },
             {
                 id: "7a37a2e3-9faf-5da2-bb0f-61c9d20f6015",
-                type: "personal",
-                descriptions: "Finishes Malone meurt.",
+                description: "Finishes Malone meurt.",
                 date: "30 May",
+                type: "personal",
             },
             {
                 id: "e5e7f98d-8810-5e6d-acde-599a4315113e",
@@ -501,7 +501,7 @@ export const timelineData = [
             {
                 id: "9f80bb5d-2ef9-5ccd-a82a-6bb1f72e5b78",
                 type: "global",
-                date: "24 June 1948 – 12 May 1949",
+                date: "24 June 1948 - 12 May 1949",
                 description:
                     "Berlin Blockade by the Soviet Union forces in East Germany results in the Berlin Airlift to deliver supplies to West Berlin by Western Allies. ",
             },
@@ -673,6 +673,3310 @@ export const timelineData = [
                     '"Three Dialogues" published in Transition Forty-Nine, no. 5.',
                 date: "10 December",
                 type: "personal",
+            },
+        ],
+    },
+    {
+        year: 1950,
+        events: [
+            {
+                id: "f135bd9e-9194-5b17-8965-c23419a0c92c",
+                description:
+                    "Samuel Beckett commissioned by UNESCO to do the English translation of the Anthology of Mexican Poetry edited by Octavio Paz.",
+                date: "January",
+                type: "personal",
+            },
+            {
+                id: "d5065c0e-2375-50fb-ae27-cb915a4660e1",
+                description:
+                    '"An extract from Watt" published in Envoy (Dublin).',
+                date: "January",
+                type: "personal",
+            },
+            {
+                id: "4d61cce9-d0dd-5af7-bd45-a741b089843d",
+                description: "Samuel Beckett finishes a draft of L'Innommable.",
+                date: "January",
+                type: "personal",
+            },
+            {
+                id: "902f86b7-b0f7-5bd4-9ff0-440a27d1af25",
+                date: "8 February",
+                description:
+                    "The Stasi, the secret police of East Germany, is established.",
+                type: "global",
+            },
+            {
+                id: "7100be2a-178b-5c3d-9e66-169296fa7f4d",
+                description:
+                    "Samuel Beckett revises Ralph Mannheim's translation of George Duthuit's Les Fauves.",
+                date: "March",
+                type: "personal",
+            },
+            {
+                id: "8448772f-2378-5d3b-8cb4-6360560f2117",
+                date: "27 April",
+                description:
+                    "Apartheid is established in South Africa, segretating races.",
+                type: "personal",
+            },
+            {
+                id: "b92bd047-d789-5b37-a568-fa73b4de491e",
+                date: "9 May",
+                description:
+                    'The "Schumann Declaration," considered to be the beginning of the European Union; later known as Europe Day.',
+                type: "personal",
+            },
+            {
+                id: "15c2c84a-e7e2-5d25-aab4-0eb1c3fa459c",
+                date: "19 May",
+                description:
+                    "Egypt closes the Suez Canal to Israeli ships and commerce.",
+                type: "personal",
+            },
+            {
+                id: "ecf3f946-a9a1-5b7c-ab96-a120c29dd63e",
+                date: "25 June",
+                description:
+                    "North Korea invades South Korea; the United States declares war on Korea.",
+                type: "personal",
+            },
+            {
+                id: "48f8a542-e366-5a15-bfc2-15b19da92e54",
+                description: "May Beckett suffers a broken leg.",
+                date: "30 June",
+                type: "personal",
+            },
+            {
+                id: "2b422cb1-c3d0-5f85-98b4-22803a8e237a",
+                description:
+                    "Samuel Beckett travels to Dublin to be with his mother.",
+                date: "c. 2 July",
+                type: "personal",
+            },
+            {
+                id: "b3c5cbd3-165f-503f-9732-ec687884f763",
+                description: "Death of May Beckett.",
+                date: "25 August",
+                type: "personal",
+            },
+            {
+                id: "43c80f23-6233-5ba4-8bb5-ea6686b03ff9",
+                description: "Samuel Beckett returns to France.",
+                date: "8 September",
+                type: "personal",
+            },
+            {
+                id: "7387afe1-58c9-5b19-bccc-dacb2f24eb7d",
+                description:
+                    "Extract from Malone meurt accepted by Georges Lambrichs for publication in Editions de Minuit's journal 84: Nouvelle Revue Littéraire.",
+                date: "4 October",
+                type: "personal",
+            },
+            {
+                id: "5ad9a290-607e-51c4-8e79-95446e3f5609",
+                description:
+                    "Suzanne Deschevaux-Dumesnil brings Molloy to Georges Lambrichs at Editions de Minuit.",
+                date: "6 October",
+                type: "personal",
+            },
+            {
+                id: "9f95608b-cafe-5594-b6f2-72332a19d7eb",
+                description:
+                    "Jérôme Lindon reads Molloy and writes to Suzanne Deschevaux-Dumesnil that Editions de Minuit will publish the novel.",
+                date: "before mid-October",
+                type: "personal",
+            },
+            {
+                id: "a3e897a5-513c-5d62-8450-bef8affc0c49",
+                description:
+                    'Extracts from Molloy and Malone meurt, translated by Samuel Beckett, are published in Transition Fifty, no. 6 as "Two Fragments."',
+                date: "20 October",
+                type: "personal",
+            },
+            {
+                id: "fbc42a01-e4e5-5899-a707-3257f2ecd0f9",
+                description:
+                    "Suzanne Deschevaux-Dumensil returns the signed contracts to Editions de Minuit for publication of the three novels Molloy, Malone meurt, L'Innommable.",
+                date: "15 November",
+                type: "personal",
+            },
+            {
+                id: "89bb810a-d06b-58fa-b74e-d9366f887203",
+                description:
+                    '"Malone s\'en conte," an extract from Malone meurt, published in 84: Nouvelle Revue Littéraire.',
+                date: "December",
+                type: "personal",
+            },
+            {
+                id: "a6caadb5-0b8b-5f7f-bacb-6bf31f858962",
+                description: 'Samuel Beckett writes "Texte pour rien, I."',
+                date: "24 December",
+                type: "personal",
+            },
+        ],
+    },
+    {
+        year: 1951,
+        events: [
+            {
+                id: "65a2c165-e820-5411-b90e-2e8ba0c1a886",
+                description: "Samuel Beckett receives proofs for Molloy.",
+                date: "22 January",
+                type: "personal",
+            },
+            {
+                id: "30022ea2-28d4-5e43-a198-72ce1188520c",
+                description: 'Samuel Beckett writes "Texte pour rien, II."',
+                date: "4 -6 February",
+                type: "personal",
+            },
+            {
+                id: "75368de0-e1af-5563-a29e-204050fe1ea8",
+                description: 'Writes "Texte pour rien, III."',
+                date: "27 February- 5 March",
+                type: "personal",
+            },
+            {
+                id: "178e3919-416a-53fd-acc4-7de91ab90384",
+                description: 'Writes "Texte pour rien, IV."',
+                date: "10 -12 March",
+                type: "personal",
+            },
+            {
+                id: "192b6223-6150-5171-96d3-e025e8f54641",
+                description: "Molloy published by Editions de Minuit.",
+                date: "12 March",
+                type: "personal",
+            },
+            {
+                id: "5bca654e-7fe5-5dd1-8165-25c817f0e35d",
+                description: 'Samuel Beckett writes "Texte pour rien, V."',
+                date: "19 -24 March",
+                type: "personal",
+            },
+            {
+                id: "787565ba-0a3e-5996-9044-cf7d0033ffe3",
+                description:
+                    "First review of Molloy by Maurice Nadeau in Combat",
+                date: "12 April",
+                type: "personal",
+            },
+            {
+                id: "19d43613-77be-5f10-9632-efb99bc283ed",
+                description:
+                    "Producer-director Charles Bensoussan expresses interest in Samuel Beckett's plays.",
+                date: "19 April",
+                type: "personal",
+            },
+            {
+                id: "fd6ccbc9-ccf5-53a8-8bb8-bf4c7b067216",
+                description: 'Samuel Beckett completes "Texte pour rien, VI."',
+                date: "28 April",
+                type: "personal",
+            },
+            {
+                id: "293bba06-8159-5845-9151-ce798c86ad1f",
+                description:
+                    "Georges Bataille publishes an essay on Molloy in Critique.",
+                date: "May",
+                type: "personal",
+            },
+            {
+                id: "4ae42a58-9924-5de5-8db1-a9ab73ce77b1",
+                description: 'Samuel Beckett writes "Texte pour rien, VII."',
+                date: "5 -21 May",
+                type: "personal",
+            },
+            {
+                id: "245252c6-7eff-507b-b4a8-957285e80683",
+                description:
+                    "Charles Bensoussan wishes to produce Eleutheria, but Samuel Beckett is uneasy about the play.",
+                date: "25 May",
+                type: "personal",
+            },
+            {
+                id: "6dcc5213-5f31-5326-be25-9c6a04a33354",
+                description: "Molloy nominated for the Prix des Critiques.",
+                date: "29 May",
+                type: "personal",
+            },
+            {
+                id: "86ab7ca8-7e27-5a8b-9939-ce58ee0f215b",
+                description: "Samuel Beckett is revising Malone meurt.",
+                date: "9 June",
+                type: "personal",
+            },
+            {
+                id: "78adca99-6c94-5eef-8274-9b63433a71c7",
+                description:
+                    "Offers an extract from Malone meurt or from En attendant Godot to Les Temps Modernes in response to a request by Simone de Beauvoir.",
+                date: "25 June",
+                type: "personal",
+            },
+            {
+                id: "9540fe28-e7e3-5f77-b459-3d77a2b0360a",
+                description: 'Beckett writes "Texte pour rien, VIII."',
+                date: "25 June - 10 July",
+                type: "personal",
+            },
+            {
+                id: "05da43ce-cb08-552a-aea6-8a9ca138d867",
+                description: "Delivers Malone meurt to Editions de Minuit. ",
+                date: "4 July",
+                type: "personal",
+            },
+            {
+                id: "9790dde6-6b2a-5545-b6ca-0dd6d6621536",
+                description:
+                    'Sends "Texte pour rien, V" ("torn off the placenta of L\'Innommable") to Jean Wahl for Deucalion.',
+                date: "8 July",
+                type: "personal",
+            },
+            {
+                id: "18af720f-b18a-5922-95a1-ffc08d049bff",
+                description: 'Writes "Texte pour rien, IX."',
+                date: "14 July - 6 August",
+                type: "personal",
+            },
+            {
+                id: "5b91577e-05a3-5d93-ad84-c160ec88bf93",
+                description:
+                    "Has corrected proofs of extract from Malone meurt in Les Temps Modernes.",
+                date: "by 26 July",
+                type: "personal",
+            },
+            {
+                id: "49c240d3-5a93-501f-b95c-de59cad2550f",
+                description: 'Writes "Texte pour rien, X."',
+                date: "8 - 18 August",
+                type: "personal",
+            },
+            {
+                id: "14c12957-73b4-5371-833c-d06d21bd54c7",
+                description: 'Writes "Texte pour rien, XI."',
+                date: "20 August - 4 September",
+                type: "personal",
+            },
+            {
+                id: "a36bee1a-52e9-5080-9063-6def2a100db3",
+                description:
+                    '"Quel malheur . . . ," an extract from Malone meurt, published in Les Temps Modernes.',
+                date: "September",
+                type: "personal",
+            },
+            {
+                id: "e1da6092-f6c7-53aa-95d3-792527fac4de",
+                date: "8 September",
+                description:
+                    "Treaty of San Francisco: 48 nations sign a peace treaty with Japan.",
+                type: "personal",
+            },
+            {
+                id: "42bf7c61-998c-569a-a742-b6216d38a58b",
+                description:
+                    "Frank and Jean Beckett visit Samuel Beckett for a fortnight.",
+                date: "18 October",
+                type: "personal",
+            },
+            {
+                id: "a994ae62-5558-519c-83fb-be7761e143f9",
+                description: "Publication of Malone meurt.",
+                date: "November",
+                type: "personal",
+            },
+            {
+                id: "4c2b3c23-d6e0-5b1f-95d2-e791622ba33b",
+                description:
+                    'Samuel Beckett writes "Texte pour rien, XII" (published as XIII).',
+                date: "7 - 23 November",
+                type: "personal",
+            },
+            {
+                id: "cdd07bd7-c36c-5e14-82ff-f508703a7373",
+                description: "Extract from Watt published in Irish Writing.",
+                date: "December",
+                type: "personal",
+            },
+            {
+                id: "c7609fb8-daed-5ba5-b14e-ae57e08f882d",
+                description:
+                    'Samuel Beckett finishes "Texte pour rien, XIII" (published as XII). ',
+                date: "20 December",
+                type: "personal",
+            },
+        ],
+    },
+    {
+        year: 1952,
+        events: [
+            {
+                id: "20cc2194-8698-5e6c-a778-89231f072c39",
+                description:
+                    "Director Roger Blin seeks a Paris theatre for En attendant Godot.",
+                date: "January",
+                type: "personal",
+            },
+            {
+                id: "6353dde3-b93b-5f28-94a3-3cbf1639f32d",
+                description:
+                    "An excerpt of En attendant Godot recorded on 6 February for broadcast on French radio,",
+                date: "17 February.	6 February",
+                type: "personal",
+            },
+            {
+                id: "fddd84c8-6806-519a-9994-d87446de09d8",
+                date: "8 February",
+                description:
+                    "Elizabeth II proclaimed Queen of the United Kingdom and the Commonwealth.",
+                type: "personal",
+            },
+            {
+                id: "a9d2e7c2-d415-5adc-84d4-c6142f828a6a",
+                description:
+                    "Bram van Velde exhibition, Galerie Maeght. Samuel Beckett writes text for the carte d'invitation.",
+                date: "15 February-10 March",
+                type: "personal",
+            },
+            {
+                id: "fa5e4777-0a35-5688-967c-c00c5babd70e",
+                description:
+                    'A subvention "pour aider le montage" awarded for the production of En attendant Godot.',
+                date: "26 February",
+                type: "personal",
+            },
+            {
+                id: "f9128b89-bfb6-5ed7-a563-4d5466c5407d",
+                date: "28 April",
+                description:
+                    "Allied occupation of Japan ends; peace treaty signed in San Francisco.",
+                type: "personal",
+            },
+            {
+                id: "d20b2f6d-64ea-53fa-b07b-01701297367f",
+                description:
+                    "Death of Eugene Jolas. Samuel Beckett writes a tribute.",
+                date: "26 May",
+                type: "personal",
+            },
+            {
+                id: "7d77ea5a-0158-557f-b98d-f48e304136a4",
+                description:
+                    "En attendant Godot in rehearsal: autumn production anticipated.",
+                date: "2 June",
+                type: "personal",
+            },
+            {
+                id: "fa8bf0a5-c26e-568b-a7c9-34200dd3783d",
+                description:
+                    "Agreement signed with France Guy, Théâtre de Poche, to qualify for subvention payment for En attendant Godot.",
+                date: "23 July",
+                type: "personal",
+            },
+            {
+                id: "d945f2e2-cf46-5c9b-b484-ca2d864fb335",
+                description:
+                    "Merlin interested in publishing a work by Samuel Beckett.",
+                date: "12 August",
+                type: "personal",
+            },
+            {
+                id: "cd011f81-0b3a-5f30-8456-aaed4627d044",
+                description: "Samuel Beckett having a cottage built in Ussy.",
+                date: "Autumn",
+                type: "personal",
+            },
+            {
+                id: "8d0fdd57-d806-5cc3-9a5f-46df14dabadf",
+                description:
+                    '"Je tiens le Greffe" ("Texte pour rien, V") published in Deucalion.',
+                date: "October",
+                type: "personal",
+            },
+            {
+                id: "d82cc63a-280b-52c9-a0b7-62d5e8dd573d",
+                description: "Publication of En attendant Godot.",
+                date: "17 October",
+                type: "personal",
+            },
+            {
+                id: "8a133caf-8567-59c8-b39d-231ff8266115",
+                description: "Geer van Velde exhibition, Galerie Maeght.",
+                date: "November",
+                type: "personal",
+            },
+            {
+                id: "1325420d-e919-529e-ae43-7d60e20cfcf6",
+                date: "1 November",
+                description:
+                    "United States tests the first hydrogen bomb in the Marshall Islands.",
+                type: "personal",
+            },
+            {
+                id: "48967fb2-4db2-5558-a282-6003d0d14139",
+                description:
+                    "Subsequent to broken agreement with the Théâtre de Poche, Samuel Beckett signs contract with Théâtre de Babylone for production of En attendant Godot.",
+                date: "2 November",
+                type: "personal",
+            },
+            {
+                id: "1ce16089-5b05-57c8-b44c-f09abc70ab4b",
+                description: "Rehearsals of En attendant Godot begin.",
+                date: "13 November",
+                type: "personal",
+            },
+            {
+                id: "b9d81ff6-6fa0-5e34-8e08-a83c2c601876",
+                description: '"Extract from Watt" published in Merlin.',
+                date: "15 December",
+                type: "personal",
+            },
+        ],
+    },
+    {
+        year: 1953,
+        events: [
+            {
+                id: "ea1b30ee-92a2-5d2c-8e02-5b74df0fd936",
+                description: "Cottage at Ussy completed.",
+                date: "January",
+                type: "personal",
+            },
+            {
+                id: "1a0b53e9-65c3-520c-816a-211545459b62",
+                description:
+                    "Premiere of En attendant Godot, Théâtre de Babylone.",
+                date: "5 January",
+                type: "personal",
+            },
+            {
+                id: "9c0b9fde-7300-5e23-9925-c380ace935c9",
+                date: "14 January",
+                description:
+                    "Joseph Broz Tito inaugurated as first President of Yugoslavia.",
+                type: "personal",
+            },
+            {
+                id: "ffbb7991-768f-5edb-83a5-7c173a1d8154",
+                description:
+                    "Boisterous spectators interrupt performance of En attendant Godot.",
+                date: "31 January",
+                type: "personal",
+            },
+            {
+                id: "38ea3c0b-9849-5013-bd65-8c58bd0bf6c4",
+                description:
+                    '"Mahood," an excerpt from L\'Innommable, published in the Nouvelle Revue Française with unauthorized cuts.',
+                date: "February",
+                type: "personal",
+            },
+            {
+                id: "d3c6c507-1184-5995-8504-6ad63dbff649",
+                description:
+                    "Alain Robbe-Grillet publishes essay on Samuel Beckett's work in Critique.",
+                date: "February",
+                type: "personal",
+            },
+            {
+                id: "ca4960e2-5f25-5256-898a-50134bd1a443",
+                description:
+                    "Samuel Beckett reads draft of Elmar Tophoven's German translation, Warten auf Godot.",
+                date: "by 19 February",
+                type: "personal",
+            },
+            {
+                id: "f88e11ef-43a2-557b-90f6-5dad74838500",
+                date: "5 March",
+                description: "Death of Stalin.",
+                type: "personal",
+            },
+            {
+                id: "dae8dc96-51fd-54ec-8701-489394d3d61a",
+                description:
+                    'Note of apology published in the Nouvelle Revue Française for cuts made to Samuel Beckett\'s "Mahood."',
+                date: "April",
+                type: "personal",
+            },
+            {
+                id: "6ada8488-65cd-551b-b8ca-3337c25a221c",
+                description:
+                    '"Trois Textes pour rien [III, VI, X]" published in Les Lettres Nouvelles.',
+                date: "May",
+                type: "personal",
+            },
+            {
+                id: "dab526d5-31ec-57f9-a2c6-6028e1300867",
+                description:
+                    "Frank and Jean Beckett visit Samuel Beckett in Paris and Ussy.",
+                date: "12-26 May",
+                type: "personal",
+            },
+            {
+                id: "61e5a82b-7808-5520-a80b-ef5156c8fc22",
+                description:
+                    "Offer received from Mrs. Garson Kanin and Thornton Wilder for an English translation and production in the United States of En attendant Godot.",
+                date: "15 May",
+                type: "personal",
+            },
+            {
+                id: "aeb5cb47-915a-5ecc-b8ec-db35bb9f22ef",
+                description: "Publication of L'Innommable.",
+                date: "20 May",
+                type: "personal",
+            },
+            {
+                id: "58bcc58b-b4a7-5bf6-8f62-be6c596ec35f",
+                description:
+                    "Barney Rosset, Grove Press, offers to publish English translations of En attendant Godot, Molloy, Malone meurt, and takes an option for L'Innommable.",
+                date: "before 22 May",
+                type: "personal",
+            },
+            {
+                id: "308a7dc7-4f6f-50f3-add7-ad8a6520feb0",
+                description:
+                    '"Texte pour rien, XI" published in Arts-Spectacles.',
+                date: "3 July",
+                type: "personal",
+            },
+            {
+                id: "82e6a073-809a-5e81-b9f4-d95e349b6bfb",
+                date: "23 July",
+                description:
+                    "Armistice signed between Korea and the United States.",
+                type: "personal",
+            },
+            {
+                id: "6daf8e5b-48a9-590a-9d4a-afb11c53679d",
+                description:
+                    "Samuel Beckett working in Paris with Patrick Bowles on the English translation of Molloy.",
+                date: "by 27 July",
+                type: "personal",
+            },
+            {
+                id: "c164c68f-91d0-5628-826c-d45c710ef0da",
+                description:
+                    "Imprint date of Watt, Collection Merlin, Olympia Press.",
+                date: "31 August",
+                type: "personal",
+            },
+            {
+                id: "bbf1acca-aec9-55cc-8b1d-c5a06d8e98a7",
+                description:
+                    "Reprint of En attendant Godot with cuts and changes made for performance.",
+                date: "September",
+                type: "personal",
+            },
+            {
+                id: "11d22ab9-726a-55fa-8002-ae6be6ee2e52",
+                description:
+                    "Nadeau publishes essay on L'Innommable in Les Lettres Nouvelles.",
+                date: "September",
+                type: "personal",
+            },
+            {
+                id: "c032ff13-19bb-584d-9970-a1d5b06fed0a",
+                description:
+                    "Samuel Beckett meets Pamela Mitchell for the first time in Paris.",
+                date: "September",
+                type: "personal",
+            },
+            {
+                id: "e774eec2-f395-5ef2-bffd-74bb26d2941b",
+                description: "Thomas MacGreevy in Paris.",
+                date: "early September",
+                type: "personal",
+            },
+            {
+                id: "73dc0458-c68e-5d80-9bfb-222c19c51508",
+                description:
+                    "Samuel Beckett attends premiere of Warten auf Godot, Schauspielhaus, Berlin.",
+                date: "8 September",
+                type: "personal",
+            },
+            {
+                id: "3ac3ea12-547d-5a48-b4ff-6e3e66667616",
+                description:
+                    '"Extract from Molloy," translated by Patrick Bowles, published in Merlin.',
+                date: "15 September",
+                type: "personal",
+            },
+            {
+                id: "9878baee-aa36-52e0-b97e-2f571be9fd5a",
+                description:
+                    "Reprise of En attendant Godot, Théâtre de Babylone.",
+                date: "25 September",
+                type: "personal",
+            },
+            {
+                id: "b27e4077-ee85-5e06-aace-1a8bdd44e777",
+                description:
+                    "Samuel Beckett works on French translation of Watt with Daniel Mauroc.",
+                date: "by 31 October",
+                type: "personal",
+            },
+            {
+                id: "10aca531-9f08-5af0-a2c8-da2e89fb3acf",
+                description:
+                    '"Texte pour rien, XIII" published in Le Disque Vert.',
+                date: "November",
+                type: "personal",
+            },
+            {
+                id: "749e1f96-7329-5e5c-abf4-22a64eb8db61",
+                description:
+                    "Tour of the Théâtre de Babylone production of En attendant Godot: Germany, Italy, and France.",
+                date: "16 November - 12 December",
+                type: "personal",
+            },
+            {
+                id: "d413446b-0478-5424-9bb0-fa58b24687e3",
+                description:
+                    "Opening performance of Godot, by prisoners, in Lüttringhausen, in a German translation by one of their number.",
+                date: "29 November",
+                type: "personal",
+            },
+            {
+                id: "f7130f75-512a-5a2c-9c58-7eaec63bae49",
+                description: "Ethna MacCarthy in Paris.",
+                date: "14 December",
+                type: "personal",
+            },
+        ],
+    },
+    {
+        year: 1954,
+        events: [
+            {
+                id: "1fa6ed99-1c3f-537e-b828-c1a28e0d513c",
+                description:
+                    "Samuel Beckett attends Cirque Médrano with Jean Martin to see Buster Keaton perform.",
+                date: "12 January",
+                type: "personal",
+            },
+            {
+                id: "0780edeb-98ae-520a-8ae8-b3e71163b859",
+                description:
+                    "Correcting proofs of Waiting for Godot for Grove Press. Reviewing Trino Martínez Trives's translation Esperando a Godot. Refuses to allow Editions de Minuit to publish Mercier et Camier.",
+                date: "20 January",
+                type: "personal",
+            },
+            {
+                id: "f7652d73-c52c-57e8-945a-a470e978d07f",
+                description:
+                    "Reviews German translation of Molloy by translator Erich Franzen in a series of letters.",
+                date: "23 January - 17 February",
+                type: "personal",
+            },
+            {
+                id: "a033c93e-3d40-5610-93f6-78edc1cc258b",
+                description:
+                    "Jack B. Yeats exhibition, Galerie Beaux-Arts, Paris.",
+                date: "February",
+                type: "personal",
+            },
+            {
+                id: "047e3c32-7370-563e-a52d-8646b3025387",
+                description:
+                    "Blin's production of Warten auf Godot opens in the Schauspielhaus, Zurich.",
+                date: "25 February",
+                type: "personal",
+            },
+            {
+                id: "6c98c942-abe0-5e63-8cea-f250353b3a76",
+                description: '"Extract from Molloy" published in Paris Review.',
+                date: "March",
+                type: "personal",
+            },
+            {
+                id: "e2ec6f28-5a7e-5ad3-a1ae-cf91e6a8e774",
+                description:
+                    "Samuel Beckett asks Jacques Putman, Georges Duthuit, and Pierre Schneider to contribute short essays on the painting of Jack B. Yeats for Les Lettres Nouvelles.",
+                date: "March",
+                type: "personal",
+            },
+            {
+                id: "40133535-f5d6-5907-95c9-5296b5a7b57f",
+                date: "13 March-7 May",
+                description:
+                    "Battle of Dien Bien Phu, climactic confrontation between the French and Viet Minh communist revolutionaries.",
+                type: "personal",
+            },
+            {
+                id: "c154714c-dfc1-5615-9981-f4f355977445",
+                description:
+                    '"Molloy," an excerpt from Molloy, published in New World Writing.',
+                date: "April",
+                type: "personal",
+            },
+            {
+                id: "e521d421-f375-519d-91cc-72a359fab648",
+                description:
+                    'Samuel Beckett\'s "Hommage à Jack B Yeats" published in Les Lettres Nouvelles.',
+                date: "April",
+                type: "personal",
+            },
+            {
+                id: "7560db46-d8a5-587b-b17b-2b132f0d1347",
+                description:
+                    "Samuel Beckett responds to Lord Chamberlain's Office censorship of text of Waiting for Godot.",
+                date: "14 April",
+                type: "personal",
+            },
+            {
+                id: "5aa3a590-73a2-519f-873b-5ee1063b07e5",
+                description: "Pamela Mitchell in Paris",
+                date: "May",
+                type: "personal",
+            },
+            {
+                id: "9b02a40b-347d-54cb-9403-aecc5d92d94b",
+                description:
+                    "Two sonnets by Miguel de Guevara, translated by Samuel Beckett for the Anthology of Mexican Poetry, published in Hermathena.",
+                date: "May",
+                type: "personal",
+            },
+            {
+                id: "dde2da8a-0a14-5eed-91cc-f5deb16b4372",
+                description:
+                    "Samuel Beckett leaves for Dublin to be with his brother Frank Beckett who is gravely ill.",
+                date: "27 May",
+                type: "personal",
+            },
+            {
+                id: "acba53ba-5949-51ea-b646-78ba7cb61af7",
+                date: "27 May",
+                description:
+                    "France and Vietnam agree to a ceasefire, marking the end of the French Indochina War.",
+                type: "personal",
+            },
+            {
+                id: "510fc445-0a1f-5321-89de-c7cae2b12788",
+                description:
+                    "Objections of the Lord Chamberlain's Office to the text of Waiting for Godot resolved.",
+                date: "23 June",
+                type: "personal",
+            },
+            {
+                id: "63fe3dd9-4fab-5a5e-a479-157225786a0f",
+                description:
+                    "Samuel Beckett has begun the English translation of Malone meurt.",
+                date: "12 July",
+                type: "personal",
+            },
+            {
+                id: "2187a6fc-58a0-5197-a6d7-a266a9165899",
+                description:
+                    "Waiting for Godot, translated by the author, published by Grove Press.",
+                date: "end of August",
+                type: "personal",
+            },
+            {
+                id: "1bba601b-ca23-5fd5-839a-44d0134bd3b4",
+                description:
+                    '"The End," translated by Richard Seaver in collaboration with the author, published in Merlin.',
+                date: "Summer-Autumn",
+                type: "personal",
+            },
+            {
+                id: "3b238ec7-c325-5868-8029-333279da1063",
+                description:
+                    "Samuel Beckett correcting proofs of Pablo Palant's translation of Esperando a Godot.",
+                date: "7 September",
+                type: "personal",
+            },
+            {
+                id: "962e2456-64ca-577c-8fee-0dbba90ae9cd",
+                description: "Death of Frank Beckett.",
+                date: "13 September",
+                type: "personal",
+            },
+            {
+                id: "c0348666-47d9-5789-8061-ea38b4460754",
+                description:
+                    "Samuel Beckett meets Donald Albery, Peter Glenville, and Ralph Richardson in London on his way from Dublin to Paris.",
+                date: "24 September",
+                type: "personal",
+            },
+            {
+                id: "98ebc87c-2706-5d4e-a995-98403c254f6d",
+                description: "Samuel Beckett in Ussy.",
+                date: "26 September",
+                type: "personal",
+            },
+            {
+                id: "7890de7a-775d-5bd3-b91a-cd839db9221a",
+                description: "Watt banned in Ireland.",
+                date: "15 October",
+                type: "personal",
+            },
+            {
+                id: "2598c0bb-0a5d-5619-abe0-fef57cd13d12",
+                date: "1 November",
+                description: "Algerian War begins (Toussaint Sanglante).",
+                type: "personal",
+            },
+            {
+                id: "cded01d0-8a27-57d3-b0af-aac631850d2e",
+                description:
+                    "Samuel Beckett returns to Paris after nearly two months in Ussy.",
+                date: "19 November",
+                type: "personal",
+            },
+        ],
+    },
+    {
+        year: 1955,
+        events: [
+            {
+                id: "c805b141-65e8-5e50-b681-5469e5158ba2",
+                description:
+                    "Samuel Beckett gives Patrick Bowles final text of translation of Molloy; Bowles sends to Rosset on 23 January.",
+                date: "13 January",
+                type: "personal",
+            },
+            {
+                id: "4900e825-7cd3-50b7-ac37-5ed75a58f43a",
+                description: "Pamela Mitchell sails from France to New York.",
+                date: "27 January",
+                type: "personal",
+            },
+            {
+                id: "ed45b393-7547-504e-85e1-18018fed6f2a",
+                description:
+                    "Molloy published in English by Collection Merlin, Olympia Press.",
+                date: "March",
+                type: "personal",
+            },
+            {
+                id: "8461e1a6-0b0a-5141-8a8a-fc3b59fb8743",
+                description:
+                    "Opening of Blin's production of Wachten op Godot, Toneelgroep Theater, Arnhem.",
+                date: "6 March",
+                type: "personal",
+            },
+            {
+                id: "a74f340d-b770-58de-a767-3ac59d1efa28",
+                description:
+                    "Samuel Beckett completes draft of play eventually entitled Fin de partie.",
+                date: "13 March",
+                type: "personal",
+            },
+            {
+                id: "f351ce3f-cda3-5410-b436-a92244124149",
+                description:
+                    "Delivers manuscript of Nouvelles et Textes pour rien to Editions de Minuit.",
+                date: "27 March",
+                type: "personal",
+            },
+            {
+                id: "2d43e060-87a8-518d-b35b-059069af6dbc",
+                date: "April",
+                description: "State of emergency declared in Algeria.",
+                type: "personal",
+            },
+            {
+                id: "e2334cac-3c63-551f-aa8b-aaee2fef5728",
+                description:
+                    "Samuel Beckett is best man at the wedding of Stephen and Solange Joyce in Paris.",
+                date: "15 April",
+                type: "personal",
+            },
+            {
+                id: "caa5381f-6a96-5a2f-b904-c084dd92025f",
+                description:
+                    '"Deux textes pour rien [I, IX]" published in Monde Nouveau/Paru.',
+                date: "May-June",
+                type: "personal",
+            },
+            {
+                id: "5494163d-03a9-554b-a5c1-b24f864881c7",
+                description:
+                    "Esperando a Godot performed in Madrid, despite ban on publicity and public performance.",
+                date: "28 May",
+                type: "personal",
+            },
+            {
+                id: "eacb9e41-075c-5ae6-969a-21d2aebfcce0",
+                date: "June",
+                description: "Widespread strikes in France.",
+                type: "global",
+            },
+            {
+                id: "7ea8552c-0935-50f5-89fc-692c7e5f4d92",
+                description:
+                    "Samuel Beckett meets in Paris the American painter Joan Mitchell (former wife of Barney Rosset).",
+                date: "week of 5 June",
+                type: "personal",
+            },
+            {
+                id: "b7955648-3538-5124-bb0e-4699ab836879",
+                description:
+                    "Attends opening of Alan Schneider's production of Thornton Wilder's The Skin of Our Teeth, Théâtre Sarah Bernhardt, Paris.",
+                date: "28 June",
+                type: "personal",
+            },
+            {
+                id: "ff639200-9df0-5c80-9ed4-c691a94e670a",
+                description: "Molloy published by Grove Press.",
+                date: "August",
+                type: "personal",
+            },
+            {
+                id: "8b98564b-c5c6-5e28-a6b1-9ff6fbd369cb",
+                description:
+                    "Opening of Waiting for Godot, Arts Theatre, London, directed by Peter Hall.",
+                date: "3 August",
+                type: "personal",
+            },
+            {
+                id: "8f746e72-a0d9-57d0-af00-e8fd1525e6e8",
+                description:
+                    "Samuel Beckett completes draft of his translation of Malone meurt. Has written a mime scenario for Deryk Mendel.",
+                date: "18 August",
+                type: "personal",
+            },
+            {
+                id: "07b7ded1-6a6f-51e0-bd84-fb890186aae5",
+                description:
+                    "Extract from Watt broadcast on the BBC Third Programme.",
+                date: "7 September",
+                type: "personal",
+            },
+            {
+                id: "f7982222-6f7e-57d9-98aa-246216759ea6",
+                description:
+                    "Waiting for Godot transfers to the Criterion Theatre, London.",
+                date: "12 September",
+                type: "personal",
+            },
+            {
+                id: "9e6c8780-006c-581e-8a58-d237430203b9",
+                description:
+                    '"Trois poèmes" ("Accul," "Mort de A.D.," and "vive morte") published in Cahiers des Saisons, a Minuit journal previously entitled 84: Nouvelle Revue Littéraire.',
+                date: "October",
+                type: "personal",
+            },
+            {
+                id: "5ba9a13a-6541-55a9-b0b0-c3a21edd1c25",
+                description:
+                    "Samuel Beckett spends several days with Giorgio and Asta Joyce in Zurich. Visits Joyce's grave.",
+                date: "8 October",
+                type: "personal",
+            },
+
+            {
+                id: "763e24e4-f194-5ca3-bc97-5b4032045cef",
+                description:
+                    "Opening of Waiting for Godot at the Pike Theatre, Dublin.",
+                date: "28 October",
+                type: "personal",
+            },
+            {
+                id: "e459dbf8-a416-5694-87b3-e7f151caaa13",
+                description:
+                    '"Henri Hayden, homme-peintre" published in Arts-documents (Geneva).',
+                date: "November",
+                type: "personal",
+            },
+            {
+                id: "f1bd676a-5800-5260-9311-c36d50d8169a",
+                description:
+                    "Samuel Beckett meets Donald Albery, London producer of Waiting for Godot, in Paris.",
+                date: "3 November",
+                type: "personal",
+            },
+            {
+                id: "c2fbd348-4b3b-525f-b4ad-d99d6e2a4565",
+                description:
+                    "Composer John Beckett working in Paris with Deryk Mendel on music for a mime (Act Without Words I).",
+                date: "26 November",
+                type: "personal",
+            },
+            {
+                id: "96f14e16-1a2f-5e38-a94a-6aef1f5f9fe6",
+                description: "Imprint date of Nouvelles et Textes pour rien.",
+                date: "15 November",
+                type: "personal",
+            },
+            {
+                id: "f8205159-b75e-5ecb-944d-7b6caf106eb7",
+                description:
+                    "Samuel Beckett discusses Waiting for Godot with Alan Schneider in Paris.",
+                date: "from 26 November",
+                type: "personal",
+            },
+            {
+                id: "4a889c26-fe15-5980-93ce-a91a381ab5b3",
+                description:
+                    "Samuel Beckett and Schneider attend several performances of London production of Waiting for Godot. Samuel Beckett meets German actress Elizabeth Bergner in London.",
+                date: "early December",
+                type: "personal",
+            },
+            {
+                id: "16998334-f5db-52b6-a52a-e7051868e508",
+                description:
+                    "Samuel Beckett attends 100th performance of Waiting for Godot in London.",
+                date: "8 December",
+                type: "personal",
+            },
+        ],
+    },
+    {
+        year: 1956,
+        events: [
+            {
+                id: "a0100873-42b1-55ac-a7af-83cce09f7b6f",
+                description:
+                    "US opening of Waiting for Godot, Coconut Grove Playhouse, Miami, directed by Alan Schneider.",
+                date: "3 January",
+                type: "personal",
+            },
+            {
+                id: "48b50af6-ef06-5fa9-bb82-d21612cce633",
+                description: "All editions of Molloy banned in Ireland.",
+                date: "20 January",
+                type: "personal",
+            },
+            {
+                id: "37a170a0-892d-5488-8939-62499904125b",
+                description:
+                    "Samuel Beckett declines nomination for election to the Irish Academy of Letters.",
+                date: "21 January",
+                type: "personal",
+            },
+            {
+                id: "68f369ab-655c-5223-a510-53538e115b02",
+                description:
+                    "Waiting for Godot published by Faber and Faber, in expurgated version.",
+                date: "10 February",
+                type: "personal",
+            },
+            {
+                id: "8633749f-5ff7-57b0-a3b9-ad5569ff9743",
+                description:
+                    "Samuel Beckett begins translation of L'Innommable.",
+                date: "27 February",
+                type: "personal",
+            },
+            {
+                id: "e7a995c2-1c45-5aa7-8b7c-62b2c056f957",
+                date: "2 March",
+                description: "Morocco gains independence from France",
+                type: "personal",
+            },
+            {
+                id: "710fd66d-9a7b-5ccf-a40c-1ea2783b134c",
+                date: "20 March",
+                description: "Tunisia gains independence from France.",
+                type: "personal",
+            },
+            {
+                id: "58c362af-8fd3-5791-8b9d-782110cb9e07",
+                description:
+                    "Extract from Malone Dies published in Irish Writing.",
+                date: "April",
+                type: "personal",
+            },
+            {
+                id: "6f9caa82-cf58-502b-9ef1-8d5a101b2ab6",
+                description:
+                    "New York opening of Waiting for Godot at the John Golden Theatre, directed by Herbert Bergdorf.",
+                date: "19 April",
+                type: "personal",
+            },
+            {
+                id: "c3cfa174-86a0-5c3c-9da0-b7b964793867",
+                description:
+                    "Samuel Beckett revises Fin de partie for Marseille Festival of the Avant Garde in August.",
+                date: "May-June",
+                type: "personal",
+            },
+            {
+                id: "18ff8ee1-f3b3-5602-b979-68a349f3bfa4",
+                description:
+                    "Declines request by Cyril Cusack to write a tribute to George Bernard Shaw.",
+                date: "1 June",
+                type: "personal",
+            },
+            {
+                id: "a78fecca-9698-523d-898b-121996e0ed00",
+                description:
+                    "Reprise of En attendant Godot, Théâtre Hébertot, Paris.",
+                date: "14 June - 23 September",
+                type: "personal",
+            },
+            {
+                id: "12f2d8df-eb29-5ce6-89ba-3cf7f3e555cb",
+                description:
+                    "Samuel Beckett invited to write a radio play for the BBC.",
+                date: "21 June",
+                type: "personal",
+            },
+            {
+                id: "79007040-196d-53ed-a569-1f3005e0fd00",
+                description:
+                    "Makes acquaintance of Avigdor Arikha at home of Alain Bosquet.",
+                date: "25 June",
+                type: "personal",
+            },
+            {
+                id: "1412f617-8db1-5990-89c9-045b9da08faa",
+                description:
+                    "Fin de partie and Acte sans paroles will not be produced in Marseille Festival.",
+                date: "8 July",
+                type: "personal",
+            },
+            {
+                id: "91423819-c729-53ff-8ef9-b7f7c0870ef1",
+                description: "Alan Schneider in Paris.",
+                date: "18-28 July",
+                type: "personal",
+            },
+            {
+                id: "3da83f97-7d18-52e7-aca9-c66235bd7a0f",
+                description:
+                    "Samuel Beckett accepts proposal by Limes Verlag to publish his collected poems in German with French and English originals.",
+                date: "21 July",
+                type: "personal",
+            },
+            {
+                id: "b94e5b41-dfd4-5f20-89a5-c4d1f5d0dde8",
+                date: "26 July",
+                description: "Suez Canal nationalized by Egypt",
+                type: "personal",
+            },
+            {
+                id: "87d82dcd-a675-5c72-aae4-5518e0b95680",
+                description:
+                    '"Waiting for Godot" published in Theatre Arts (New York).',
+                date: "August",
+                type: "personal",
+            },
+            {
+                id: "d67bc5ff-ab2d-5d39-94e6-13e49fffa778",
+                description:
+                    "Samuel Beckett meets Goddard Lieberson, director of Columbia Records, New York, who brings him test recording of Waiting for Godot.",
+                date: "11 August",
+                type: "personal",
+            },
+            {
+                id: "3bf39cf0-a826-5565-8395-57af93e04cd8",
+                description: "Writing All That Fall for the BBC.",
+                date: "23 August",
+                type: "personal",
+            },
+            {
+                id: "069acaa1-4800-5750-b10b-88e809f9b07b",
+                description:
+                    '"L\'écriture est gravure" by Jean Wahl, translated by the author with the assistance of Samuel Beckett as "The word is graven," published in Verve with Marc Chagall\'s "Illustrations for the Bible."',
+                date: "September",
+                type: "personal",
+            },
+            {
+                id: "47a78014-aec5-52f1-9521-225a27b3bfa0",
+                description: "Extract from Watt, the BBC Third Programme.",
+                date: "7 September",
+                type: "personal",
+            },
+            {
+                id: "d6be73ad-99ed-57d2-a4df-ba28cad7d84a",
+                description:
+                    "Samuel Beckett sends his first radio play All That Fall to the BBC.",
+                date: "27 September",
+                type: "personal",
+            },
+            {
+                id: "065a3292-c06c-5eb4-80ec-dbbfec5adb5f",
+                description: "Malone Dies published by Grove Press.",
+                date: "October",
+                type: "personal",
+            },
+            {
+                id: "1d8e61ea-b058-5e06-83f8-f5c6975dfe33",
+                description:
+                    "Fin de Partie in preliminary rehearsal at the Théâtre de l'Oeuvre, Paris.",
+                date: "October",
+                type: "personal",
+            },
+            {
+                id: "caa2f7aa-30c6-57ef-82ec-f5e51c7cee29",
+                date: "23 October-10 November",
+                description:
+                    "Hungarian Revolution: begun by student protest, a populist revolt against the government of the People's Republic of Hungary against its Soviet imposed policies. Soviet forces invade Budapest and other regions from 4 to 10 November to crush the revolt.",
+                type: "personal",
+            },
+            {
+                id: "23ef1394-851e-52be-9c3b-c3131b8ea62f",
+                date: "29 October",
+                description: "Suez War begins; ceasefire on 6 November.",
+                type: "personal",
+            },
+            {
+                id: "8e3429cf-0123-55c4-9d61-857f7612e587",
+                description:
+                    '"Yellow" from More Pricks Than Kicks published in New World Writing.',
+                date: "November",
+                type: "personal",
+            },
+            {
+                id: "2a6eef19-2502-5827-90ad-d6ab0617e489",
+                date: "4 - 11 November",
+                description:
+                    "Hungarian Revolution: Soviet troops invade Hungary to crush the revolt.",
+                type: "personal",
+            },
+            {
+                id: "65cb9acd-37ad-5a4d-a947-f7ddbc54a186",
+                description:
+                    "John Calder Ltd proposes to publish Samuel Beckett's three novels (Molloy, Malone Dies, The Unnamable) in a single volume in England.",
+                date: "11 November",
+                type: "personal",
+            },
+            {
+                id: "e3b7c7a3-11ce-5a9b-bc6d-3334526a2196",
+                description:
+                    'Samuel Beckett "pre-rehearsing" Fin de partie with Jean Martin and Roger Blin for Théâtre de L\'Oeuvre, Paris.',
+                date: "28 November",
+                type: "personal",
+            },
+        ],
+    },
+    {
+        year: 1957,
+        events: [
+            {
+                id: "fdbaaa59-d432-5d59-8a99-c3886511bd9f",
+                date: "04 January",
+                description:
+                    "Samuel Beckett is writing “The Gloaming” (abandoned, later <i>Rough for Theatre I</i>).",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "256c98a5-2caf-5f1d-9980-5d250dd6d846",
+                date: "07 January",
+                description:
+                    "All police powers in Algiers taken over by General Massu.",
+                type: "global",
+                additional: "headline",
+            },
+            {
+                id: "5b1c4e0d-ba25-52a2-b711-6a47edd6a686",
+                date: "10-19 January",
+                description:
+                    "<i>Waiting for Godot</i> with an all black cast at the Shubert Theatre in Boston. It opened on 21 January at the Ethel Barrymore Theatre, New York.",
+                type: "personal",
+                additional: "image  see works file",
+            },
+            {
+                id: "74c3a2d1-420a-5832-9e09-9a478b88dd96",
+                date: "13 January",
+                description:
+                    "<i>All That Fall</i> broadcast on the BBC Third Programme. ",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "97a8abc9-66c0-5096-82ea-787c290b04b4",
+                date: "30 January",
+                description:
+                    "<i>Fin de Partie</i> and <i>Acte sans paroles</i> published, <i>Editions de Minuit</i>.",
+                type: "personal",
+                additional:
+                    "https://www.foldvaribooks.com/pictures/1291.jpg?v=1504617993",
+            },
+            {
+                id: "0a45b69a-adfc-5914-a9a4-220e11fde26b",
+                date: "February",
+                description:
+                    "Beckett begins English translation of <i>L'Innommable</i>.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "208f3ebc-c219-557a-8f5b-ee4f75b3fa64",
+                date: "c. 11-15 February",
+                description:
+                    "In Paris, John Beckett and Deryk Mendel coordinate music and movements for <i>Acte sans paroles I</i>.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "9f61dfb4-03cb-5c3f-92ce-5fc9bcfcde6c",
+                date: "19 February",
+                description:
+                    "Beckett's first meeting with BBC radio director Donald McWhinnie, in Paris.",
+                type: "personal",
+                additional: "image",
+            },
+            {
+                id: "94ae1a44-4eed-56f3-8d39-4a86382d4208",
+                date: "March",
+                description:
+                    "<i><i>Tous ceux qui tombent</i></i> published in Les Lettres Nouvelles. ",
+                type: "personal",
+                additional:
+                    "https://andalusiabooks.files.wordpress.com/2012/08/les-lettres-nouvelle_0002.jpg",
+            },
+            {
+                id: "8626222e-b29e-58c1-817d-80dc210ec23b",
+                date: "15 March",
+                description: "<i>Murphy</i> published by Grove Press.",
+                type: "personal",
+                additional:
+                    "https://upload.wikimedia.org/wikipedia/en/0/05/Beckett_Murphy.jpg",
+            },
+            {
+                id: "a1210988-1770-51cc-a747-522bac6be70a",
+                date: "21 March",
+                description:
+                    "Beckett supervises rehearsals of <i>Fin de partie</i>, Royal Court Theatre, London.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "4b4e62d1-252b-5ea5-b79e-222da06d0b81",
+                date: "28 March",
+                description:
+                    "Death of Jack B. Yeats in Dublin; Samuel Beckett unable to attend the funeral.",
+                type: "global",
+                additional:
+                    "https://upload.wikimedia.org/wikipedia/commons/4/42/Jack_Butler_Yeats.jpg",
+            },
+            {
+                id: "9ef43e79-1e30-5c8d-b7db-675d8dc26989",
+                date: "2 April",
+                description:
+                    "Premiere of <i>Fin de partie</i>, as part of the French Festival Week in London.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "9f013c68-4891-5f5c-a573-f91b07d0f92a",
+                date: "30 April",
+                description:
+                    "<i>Fin de partie</i>, Studio des Champs-Elysées, Paris.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "a131cf7a-7aca-59f5-a1c4-c0b1cc0c39e3",
+                date: "2 May",
+                description:
+                    "<i>Fin de partie</i>, in French with the original London cast, BBC Third Programme.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "f6a6ac19-1943-59eb-bf16-c978fac6045f",
+                date: "7 May",
+                description:
+                    "Beckett begins English translation of <i>Fin de partie</i>.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "599c9c63-5758-599c-ac46-e73525c53e78",
+                date: "22 May",
+                description:
+                    "The term “Le Nouveau Roman” coined (by Emile Henriot in Le Monde, reviewing works by Alain Robbe-Grillet and Nathalie Sarraute.",
+                type: "global",
+                additional: "image",
+            },
+            {
+                id: "08dfcb37-b7d7-5543-8464-c9e9ecac0a3b",
+                date: "After 27 May",
+                description:
+                    "Publication of <i>Lieutenant en Algérie</i> by Jean-Jacques Servan-Schreiber; it denounces French military policy in Algeria.",
+                type: "global",
+                additional: "none",
+            },
+            {
+                id: "fb3bcf0f-f754-5bc4-82f6-07582388bf15",
+                date: "24 August",
+                description:
+                    "Beckett completes <i>Acte sans paroles II</i>, for Deryk Mendel.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "bd51672b-c188-5c91-8663-db1b43d8a27d",
+                date: "30 August",
+                description:
+                    "<i>All That Fall</i> published by Faber and Faber.",
+                type: "personal",
+                additional:
+                    "https://upload.wikimedia.org/wikipedia/en/thumb/2/2b/All_That_Fall.jpg/220px-All_That_Fall.jpg",
+            },
+            {
+                id: "a6841a28-ec7d-535a-ba87-9eb96b266b4e",
+                date: "4 October",
+                description:
+                    "Launch of the first earth satellite, the Soviet Sputnik.",
+                type: "global",
+                additional:
+                    "headline https://en.wikipedia.org/wiki/Sputnik_1#/media/File:Sputnik-stamp-ussr.jpg; https://www.nps.gov/articles/sputniki.htm",
+            },
+            {
+                id: "9aa94791-bad2-5866-9d81-14663d0c7023",
+                date: "8 October",
+                description:
+                    "Alan Schneider in Paris to discuss <i>Fin de partie</i>; he and Beckett attend the Paris production together, twice.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "3d7cd46f-9463-56c3-a981-3b81c35b292d",
+                date: "12 October",
+                description:
+                    "<i>Fin de partie</i> closes after 97 performances in Paris.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "ecb7e923-c38a-54fe-9eb9-50744bc0372f",
+                date: "After 18 October",
+                description:
+                    "<i>Tous ceux qui tombent</i> published by Editions de Minuit.",
+                type: "personal",
+                additional:
+                    "http://www.leseditionsdeminuit.fr/images/livre_galerie_9782707302052.jpg",
+            },
+            {
+                id: "d6067568-0789-5259-9751-11186618de11",
+                date: "10 December",
+                description:
+                    "Extracts from <i>Molloy</i> read by Patrick Magee, with music by John Beckett, BBC Third Programme.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "0d1eaf95-e844-5075-b15f-6db6590dd8d2",
+                date: "14 December",
+                description:
+                    "<i>From an Abandoned Work</i> read by Patrick Magee, BBC Third Programme.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "35e9a076-e763-5d5a-a958-48bf483924bb",
+                date: "20 December",
+                description:
+                    "Albert Camus awarded the Nobel Prize in Literature.",
+                type: "global",
+                additional: "image",
+            },
+        ],
+    },
+    {
+        year: 1958,
+        events: [
+            {
+                id: "d2a3cee4-8d63-59f9-a0f8-76a21a55aa08",
+                date: "28 January",
+                description:
+                    "Premiere of <i>Endgame</i>, Cherry Lane Theatre, New York.",
+                type: "personal",
+                additional:
+                    "http://www.cherrylanetheatre.org/images/uploads/161/endgame_program_1957__main.jpg",
+            },
+            {
+                id: "162534b7-1f1e-5afb-b473-6d0f1a6f76c4",
+                date: "31 January",
+                description:
+                    "Launch of the first earth satellite, Explorer 1, by the United States.",
+                type: "global",
+                additional:
+                    "https://upload.wikimedia.org/wikipedia/commons/7/72/JPL_-_Explorer_1_is_test-mated_before_launch.jpg",
+            },
+            {
+                id: "38c2cada-6c66-59e1-ac55-540509524ccf",
+                date: "by 17 February",
+                description:
+                    "Samuel Beckett withdraws his two mimes and a reading of <i>All That Fall</i> from the Dublin Theatre Festival.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "a7ee2993-038c-5b3d-8932-d5926e008a49",
+                date: "23 February",
+                description:
+                    "Beckett completes first draft of English translation, <i>The Unnamable</i>.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "c97c8ad5-4f26-5ddc-81ea-d352bd980dd4",
+                date: "27 February",
+                description:
+                    "Samuel Beckett withdraws all his work from Irish production because of censorship.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "d5f5b34d-1e6e-5af2-b92b-916fe310219a",
+                date: "7 March",
+                description: "<i>Malone Dies</i> published by John Calder.",
+                type: "personal",
+                additional:
+                    "https://pictures.abebooks.com/SHAPERO/md/md22841252761.jpg",
+            },
+            {
+                id: "8690462b-c96e-55cf-a197-cd82e66030bb",
+                date: "17 March",
+                description: "Beckett completes <i>Krapp's Last Tape</i>.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "d0bf24dc-c995-5fcd-9967-380bb9f00e56",
+                date: "25 April",
+                description:
+                    "<i>Endgame</i>, followed by Act Without Words I, published by Faber and Faber.",
+                type: "personal",
+                additional: "image",
+            },
+            {
+                id: "e292ffce-2829-5dce-be98-554287a0ba3d",
+                date: "5 May",
+                description:
+                    "Beckett meets Alain Resnais to discuss film of <i>Tous ceux qui tombent</i>. ",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "cd24492c-d119-5acf-95f4-c179bed020df",
+                date: "7-10 May",
+                description:
+                    "Beckett visits Bern to attend Bram van Velde's retrospective.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "06fc007c-43cc-5880-b4b6-7b7e2b6849e9",
+                date: "13 May",
+                description: "“May 1958 Crisis” in Algeria.",
+                type: "global",
+                additional:
+                    "https://upload.wikimedia.org/wikipedia/commons/3/30/Algerian_war_collage_wikipedia.jpg",
+            },
+            {
+                id: "7d43e101-0ba5-57fc-9c43-74bbd918e9d0",
+                date: "29 May",
+                description:
+                    "Charles De Gaulle appointed Président du Conseil by President Coty, France.",
+                type: "global",
+                additional: "none",
+            },
+            {
+                id: "2078e57d-bd21-56b4-86c2-e6995e4ccec6",
+                date: "1 June",
+                description:
+                    "De Gaulle's cabinet approved by the Assemblée Nationale.",
+                type: "global",
+                additional: "none",
+            },
+            {
+                id: "2ab5f17f-f645-5dc6-96d2-e16f300bfbe4",
+                date: "18 June",
+                description:
+                    "Extract from <i>Malone Dies</i> read by Patrick Magee, with music composed by John Beckett, BBC Third Programme.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "e5d36fc5-d76f-53e3-9f47-de44dc874286",
+                date: "8 July",
+                description:
+                    "Beckett begins a three week holiday with Suzanne in Yugoslavia.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "982e7b0b-df9e-54c0-a8d7-a2af48ca4cf8",
+                date: "15 August",
+                description:
+                    "Beckett dates early draft of an abandoned play (later, <i>Rough for Theatre II</i>).",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "d5f14c31-4aca-5661-9532-bcf6b1e19917",
+                date: "20 September",
+                description:
+                    "Samuel Beckett meets Donald McWhinnie and Patrick Magee in Paris to discuss <i>Krapp's Last Tape</i>.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "c930265c-71e2-5dc5-9ddf-3f93779e34f4",
+                date: "23 September",
+                description:
+                    "Boris Pasternak awarded the Nobel Prize in Literature. Soviet authorities require that he refuse it.",
+                type: "global",
+                additional:
+                    "https://upload.wikimedia.org/wikipedia/commons/8/8c/Boris_Pasternak_1928.jpg",
+            },
+            {
+                id: "8b3f2b65-1c8e-5cee-b977-3091da730aa9",
+                date: "28 September",
+                description:
+                    "New French constitution adopted by referendum (79% in favor).",
+                type: "global",
+                additional: "none",
+            },
+            {
+                id: "e43c6d7c-f55a-5841-b330-37d6c8de9f9d",
+                date: "29 September",
+                description: "<i>The Unnamable</i> published by Grove Press.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "38700e7d-4cbd-573d-bcfd-d5cfa9f68114",
+                date: "21 October",
+                description:
+                    "Beckett in London for a week to assist with rehearsals of <i>Krapp's Last Tape</i> and <i>Endgame</i>.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "b4917a2e-fc6a-5b7f-96f6-4fa610fa481f",
+                date: "28 October",
+                description:
+                    "Premiere of <i>Krapp's Last Tape</i> as a curtain-raiser for <i>Endgame</i>, Royal Court Theatre, London.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "bbcec923-4a15-565f-b47a-41f4d6b354bf",
+                date: "1 November",
+                description:
+                    "Beckett completes English translation (“Text I”) from <i>Textes pour rien</i>.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "96ae4576-8502-5703-a79b-a5e5ee19c77e",
+                date: "before 23 November",
+                description:
+                    "Beckett asks Barbara Bray and Donald McWhinnie to read his “aborted radio script” (<i>Embers</i>).",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "6738f5fd-5993-5af8-a33b-420aa35d0076",
+                date: "December",
+                description:
+                    "<i>Anthology of Mexican Poetry</i>, ed. Octavio Paz, translated by Samuel Beckett into English, published by Indiana University Press.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "15cd1af6-b847-5e4c-815b-dbfddaba82af",
+                date: "1 December",
+                description:
+                    "Beckett flies to Dublin for a week. Ethna MacCarthy Leventhal is dying of cancer; Thomas MacGreevy has had a serious heart attack.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "87b40bba-bcd5-53c5-a395-243bba3b865b",
+                date: "10 December",
+                description:
+                    "Boris Pasternak is required by the Soviet authorities to refuse the Nobel Prize in Literature.",
+                type: "global",
+                additional: "image",
+            },
+            {
+                id: "50fa82e1-7817-536d-9f5c-b1f0510b50a5",
+                date: "17 December",
+                description:
+                    "Samuel Beckett begins “Pim” which eventually becomes part of <i>Comment c'est</i>.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "f581ef0c-95a3-5a45-b790-368ec33381bb",
+                date: "29 December",
+                description:
+                    "Cardinal Roncalli is elected Pope, as John XXIII.",
+                type: "global",
+                additional:
+                    "https://upload.wikimedia.org/wikipedia/en/9/9f/Johnxxiii-color-tiara-sm.jpg",
+            },
+        ],
+    },
+    {
+        year: 1958,
+        events: [
+            {
+                id: "0720f1b4-27c3-54e5-9873-85d1184b08dd",
+                date: "1 January",
+                description:
+                    "Overthrow of the government of Cuban President Fulgencio Batista; Fidel Castro assumes power on 16 February. Opening of the European Common Market.",
+                type: "global",
+                additional: "none",
+            },
+            {
+                id: "1255a374-c20c-5bd7-a2ef-d93b8216ddf9",
+                date: "19 January",
+                description:
+                    "The BBC Third Programme broadcasts extracts from <i>The Unnamable</i>, read by Patrick Magee, with music by John Beckett.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "b27452e0-8cd1-5365-a6f6-8832b3d140c1",
+                date: "February",
+                description:
+                    "André Malraux appointed by De Gaulle as France's first Ministre de la Culture.",
+                type: "global",
+                additional: "image",
+            },
+            {
+                id: "89b3531f-15bb-553c-8f89-a7a3efd04c24",
+                date: "12 February-7",
+                description:
+                    "Henri Hayden exhibition, Waddington Galleries, London; catalogue includes Samuel Beckett text “Henri Hayden.”",
+                type: "personal",
+                additional:
+                    "https://upload.wikimedia.org/wikipedia/commons/3/33/Fille_assise_au_bouquet_de_fleurs%2C_1919.jpg",
+            },
+            {
+                id: "0e4c7e32-e929-5649-ab44-130ae5c28a2f",
+                date: "4 March",
+                description:
+                    "Les Lettres Nouvelles publishes <i>La dernière bande</i>.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "b23283db-4f6b-53e0-84d1-180ce4ff5cbd",
+                date: "20 March",
+                description:
+                    "Beckett reports that he has given permission to Marcel Mihalovici to make a chamber opera of <i>La dernière bande</i>.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "9a1f57a3-57ff-5de0-8078-98e37097fa20",
+                date: "20 March",
+                description:
+                    "Death of Peter Suhrkamp, Samuel Beckett's German publisher.",
+                type: "global",
+                additional:
+                    "https://upload.wikimedia.org/wikipedia/commons/d/d0/Suhrkamp_peter.png",
+            },
+            {
+                id: "638a11ed-8ee4-5ad5-8230-5ca9f41e3161",
+                date: "4 April",
+                description:
+                    "Beckett attends France-Wales rugby match at Colombes Stadium, with Claude Simon.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "2aa11fd2-2275-5ff2-926a-0949122f5dd1",
+                date: "24 May",
+                description: "Death of Ethna MacCarthy Leventhal.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "e55a460d-ecfe-5e7f-8ada-a2675e1f783b",
+                date: "24 June",
+                description:
+                    "The BBC Third Programme broadcasts <i>Embers</i>.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "376ea642-f01e-56aa-b53f-26960697b05b",
+                date: "26 June",
+                description:
+                    "Limes Verlag, Wiesbaden, publish poems as Gedichte. ",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "427a659b-dd6b-5098-9883-6e5dc1a543b0",
+                date: "2 July",
+                description:
+                    "Samuel Beckett receives honorary D. Litt. from Trinity College Dublin.",
+                type: "personal",
+                additional:
+                    "https://i.pinimg.com/474x/f4/e7/09/f4e709955fdf3db7747154518ef7ee30.jpg",
+            },
+            {
+                id: "9027f145-c1c4-5094-a58e-982c04c702f9",
+                date: "21 August",
+                description: "Death of Denis Devlin",
+                type: "global",
+                additional: "image",
+            },
+            {
+                id: "208fe905-e6f1-512c-8751-37d56c64bb5d",
+                date: "13-17 September",
+                description:
+                    "Samuel Beckett is in Sorrento where Radiotelevisione Italia awards <i>Embers</i> the Italia Prize on 15 September.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "1cfba697-977f-57f2-9b07-f3c1c2065769",
+                date: "16 September",
+                description:
+                    "De Gaulle recognizes Algeria's right to self-determination.",
+                type: "global",
+                additional: "none",
+            },
+            {
+                id: "e59d30ab-3d79-55f6-8271-e306daf8ea48",
+                date: "October",
+                description:
+                    "Olympia Press publish <i>Molloy</i>, <i>Malone Dies</i>, and <i>The Unnamable</i> as a single volume for European market; Grove Press publish the “three in one” in November.",
+                type: "personal",
+                additional:
+                    "https://pictures.abebooks.com/ELLISBKS/15900021036.jpg",
+            },
+            {
+                id: "dda7ad0e-722e-5608-89e3-ce6ac906a300",
+                date: "before 14 October",
+                description: "Beckett buys a Citroën 2CV.",
+                type: "personal",
+                additional:
+                    "https://upload.wikimedia.org/wikipedia/commons/b/b8/1956_Citro%C3%ABn_2CV_-_Flickr_-_skinnylawyer.jpg",
+            },
+            {
+                id: "607b11b3-3652-51fe-a240-2ab598bf1fb5",
+                date: "20 November",
+                description:
+                    "Beckett introduces Robert Pinget to friends in the United States.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "9002729a-5e63-5ae9-9076-e08be8bed2ca",
+                date: "18 December",
+                description:
+                    "<i>Krapp's Last Tape</i>, with <i>Embers</i> published by Faber and Faber.",
+                type: "personal",
+                additional: "none",
+            },
+        ],
+    },
+    {
+        year: 1960,
+        events: [
+            {
+                id: "2170330a-9bec-53fa-8163-36c587443bec",
+                date: "4 January",
+                description: "Death of Albert Camus.",
+                type: "global",
+                additional:
+                    "https://upload.wikimedia.org/wikipedia/commons/9/9a/Albert_Camus2.jpg",
+            },
+            {
+                id: "faa9e39e-a461-5b3b-9039-6af37b3af92a",
+                date: "after 5 January",
+                description:
+                    "Publication of <i>La dernière bande, suivi de Cendres</i> by Editions de Minuit.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "61a64e42-4cac-567a-a13d-47e4b25b81c4",
+                date: "14 January",
+                description:
+                    "<i>Krapp's Last Tape</i> opens at the Provincetown Playhouse, New York, directed by Alan Schneider.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "763a15f5-08e0-5907-b66a-350f7873e34b",
+                date: "24 January-1 February",
+                description:
+                    "Insurrection in Algiers, known as “La semaine des barricades.”",
+                type: "global",
+                additional: "none",
+            },
+            {
+                id: "f0ec5fb5-d364-50aa-afc8-3040f1bc87f5",
+                date: "2-3 February",
+                description:
+                    "The French Government takes on emergency powers to deal with the worsening situation in Algeria.",
+                type: "global",
+                additional: "none",
+            },
+            {
+                id: "39f55273-efac-53fb-b883-2725d78c0b83",
+                date: "27 March",
+                description:
+                    "Générale of <i>La dernière bande</i>, directed by Roger Blin, and Lettre morte, directed by Jean Martin, Théâtre Récamier.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "cc5c9248-1d5a-5702-ab52-39ac12d65f6d",
+                date: "30 March",
+                description:
+                    "Samuel Beckett's tribute to Sean O'Casey published in The Irish Times.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "c2bf9514-591b-5b35-bda5-a78f90aaa04c",
+                date: "31 March",
+                description:
+                    "<i>Molloy</i>, <i>Malone Dies</i>, and <i>The Unnamable</i> published by John Calder in a single volume as <i>Three Novels</i>.",
+                type: "personal",
+                additional:
+                    "https://archive.org/services/img/in.ernet.dli.2015.125753",
+            },
+            {
+                id: "1c9e177c-8d58-5420-9727-e12c42e2191c",
+                date: "27 April",
+                description:
+                    "The BBC Third Programme broadcasts <i>Waiting For Godot</i>.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "6ac3d85a-ca8d-54d0-93c5-6f1cafa8582b",
+                date: "7 May",
+                description:
+                    "Samuel Beckett lifts his embargo on production of his work in Ireland.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "54cdd3f4-223d-59cc-b478-249091f40f64",
+                date: "8 June",
+                description:
+                    "Beckett attends Berliner Ensemble production of Brecht's <i>Die Mutter</i>, Sarah Bernhardt Theatre, Paris; leaves at first opportunity.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "3bfd54fd-33bc-5d17-91c1-fb040326edb6",
+                date: "before 15 June",
+                description:
+                    "John Calder's edition of <i>Three Novels</i> is seized from Hanna's bookstore in Dublin, under Irish Government order.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "3d235745-715b-5899-9dd7-82f87ae42ba4",
+                date: "17 June",
+                description:
+                    "Beckett and Alan Schneider attend the Berliner Ensemble production of Brecht's Galileo in Paris.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "9291e1cc-9139-5e7b-9f41-f1933635b787",
+                date: "2 August",
+                description:
+                    "Beckett completes revision  of his new work, which becomes <i>Comment c'est</i>.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "9b78ac36-1d1a-52cf-8181-21acc8313084",
+                date: "8 August",
+                description:
+                    "Beckett dates a draft of what becomes <i>Happy Days</i>.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "9422c54d-9b8c-5da0-b80c-6113d727513c",
+                date: "18 August",
+                description:
+                    "Samuel Beckett writes his first letter to Harold Pinter.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "dc85aa0c-0b58-58fb-ae04-0eff0137f09d",
+                date: "23 August",
+                description:
+                    "The BBC Third Programme broadcasts <i>The Old Tune</i>, produced by Barbara Bray, with Jack MacGowran and Patrick Magee.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "27a64f70-b3ea-57bb-86f8-a92865ebc103",
+                date: "6 September",
+                description:
+                    "Vérité-Liberté publishes a Déclaration sur le Droit à l'Insoumission dans la Guerre d'Algérie signed by 121 writers and artists; it becomes known as the “Manifeste des 121.”",
+                type: "global",
+                additional: "none",
+            },
+            {
+                id: "a2bd21b3-db10-5cd9-8cd7-0f22ad292f7e",
+                date: "19 September",
+                description:
+                    "Robert Pinget's <i>La Manivelle</i> and Samuel Beckett's English text, <i>The Old Tune</i>, published by Editions de Minuit.",
+                type: "personal",
+                additional:
+                    "https://www.williamreesecompany.com/pictures/medium/WRCLIT71623.jpg",
+            },
+            {
+                id: "9e69843e-5b74-5445-a03a-dabdfe504018",
+                date: "30 September",
+                description:
+                    "Jérôme Lindon, editor of Editions de Minuit, arrested.",
+                type: "global",
+                additional: "none",
+            },
+            {
+                id: "80d99390-2b20-5c31-be7c-4b7382511e1b",
+                date: "7 October",
+                description:
+                    "A letter condemning the “apologists of desertion and disobedience” and defending the army appears in Le Figaro with 185 signatories.",
+                type: "global",
+                additional: "none",
+            },
+            {
+                id: "f5ae3fa0-efcb-5bfe-853a-7c7fe7781105",
+                date: "by 19 October",
+                description:
+                    "Beckett has begun to move into his new apartment at 38 Boulevard Saint-Jacques, Paris 14",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "e78bcf2c-1c12-57d8-9d04-47f5a376ae3d",
+                date: "4 November",
+                description:
+                    "De Gaulle outlines his conception of the “Algerian Republic.”",
+                type: "global",
+                additional: "none",
+            },
+            {
+                id: "acbb6769-8e51-570d-8c66-086083b8bb09",
+                date: "7 November",
+                description:
+                    "John F. Kennedy is elected President of the United States.",
+                type: "global",
+                additional: "none",
+            },
+            {
+                id: "c5b4521a-0008-55ec-9bbf-8d337fc2bc11",
+                date: "16 November",
+                description:
+                    "Beckett views <i>On the Bowery</i> directed by Lionel Rogosin; and returns for a second time.",
+                type: "personal",
+                additional: "none",
+            },
+        ],
+    },
+    {
+        year: 1961,
+        events: [
+            {
+                id: "1e5a4749-55be-5971-a85e-ff89ddc0a1d3",
+                date: "1 January",
+                description:
+                    "With A. J. Leventhal, Beckett attends Max Frisch's Biedermann et les incendiaires, Théâtre de Lutèce, directed by Jean-Marie Serreau.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "f77d3354-d64e-52a8-9921-ae92aa713733",
+                date: "8 January",
+                description:
+                    "The French proposal for Algerian self-determination receives 75% of the votes in a referendum.",
+                type: "global",
+                additional: "none",
+            },
+            {
+                id: "b216da83-22fd-51c6-8747-6c277b9877e5",
+                date: "After 8 January",
+                description:
+                    "<i>Comment c'est</i> published by Editions de Minuit.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "44df9267-fbaa-5003-bfa8-d6e52704b23a",
+                date: "9 January",
+                description:
+                    "Opening of Henri Hayden's exhibition at Waddington Gallery, London.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "706da070-f245-57b7-8cd3-94464af563b1",
+                date: "11 January",
+                description:
+                    "Samuel Beckett's first meeting with Harold Pinter.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "8f944bad-a671-596b-b468-2011317490aa",
+                date: "16 January",
+                description:
+                    "Beckett dates completion of a draft of <i>Happy Days</i>.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "e16e1004-e9b9-57b9-bb79-3eb3bc38ee1d",
+                date: "29 January",
+                description:
+                    "Beckett attends Harold Pinter's <i>Le Gardien</i>.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "ae03652c-62f8-53a9-a776-0fedd8a2e37a",
+                date: "13 February",
+                description:
+                    "Beckett attends concert performance of Mihalovici's opera <i>Krapp</i> at the Théâtre de Chaillot.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "531046c0-ff1c-5d75-a275-d30cfcd1ff2e",
+                date: "28 February",
+                description:
+                    "Beckett attends dress rehearsal of Mihalovici's opera <i>Krapp</i> in Bielefeld, Germany.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "89b55f77-595b-5f6b-94af-cee20ede92b3",
+                date: "4 March",
+                description:
+                    "Beckett returns to Paris, driving with the Tophovens, having visited Amsterdam, Delft, and Haarlem.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "61ec2801-f6d3-507c-8052-e1bb9a074b84",
+                date: "8-25 March",
+                description:
+                    "Samuel Beckett resident in Folkestone prior to his marriage.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "5fbb4c1d-bd5d-56fc-af84-80444e51bd3c",
+                date: "25 March",
+                description:
+                    "Samuel Beckett and Suzanne Dechevaux-Dumesnil marry in the Folkestone Registry Office, and return to Paris.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "5b514780-5cc5-528e-907c-84ceefaa145b",
+                date: "3 April",
+                description:
+                    "WNTA TV (New York) broadcasts <i>Waiting for Godot</i> directed by Alan Schneider.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "b2004c8a-87c3-5f7a-a3c7-120878711bd9",
+                date: "10 April - 5 May",
+                description:
+                    "Beckett manages rehearsals of <i>En attendant Godot</i> duirng Roger Blin's absence in London.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "8b0d029a-58ce-5a5b-91ae-6cf3e09bb5a7",
+                date: "11 April",
+                description: "Trial of Adolf Eichmann begins in Jerusalem.",
+                type: "global",
+                additional: "none",
+            },
+            {
+                id: "d1df1dfc-44f3-5593-98b6-040080f04170",
+                date: "12 April",
+                description:
+                    "Yuri Gagarin, aboard the Soviet satellite Vostok 1, becomes the first human in outer space.",
+                type: "global",
+                additional: "none",
+            },
+            {
+                id: "ffa116aa-2d06-561b-91f3-7a389de5539a",
+                date: "17 - 20 April",
+                description: "Bay of Pigs “invasion” of Cuba by US.",
+                type: "global",
+                additional: "none",
+            },
+            {
+                id: "d720ff1f-fbf5-5a32-92b2-5378bd7fac0f",
+                date: "21 April",
+                description:
+                    "Attempted coup, in Algers, by Generals Challe, Salan, Jouhaud, and Zeller, against De Gaulle's policy of self-determination for Algeria.",
+                type: "global",
+                additional: "none",
+            },
+            {
+                id: "c4c86dfa-830c-5fbb-835d-40d051dfb1eb",
+                date: "1 May",
+                description:
+                    "Cuba declares itself a Democratic Socialist Republic.",
+                type: "global",
+                additional: "none",
+            },
+            {
+                id: "b0ebfb05-9b79-5858-9894-396dffd768fd",
+                date: "3 May",
+                description:
+                    "Opening of <i>En attendant Godot</i>, Théâtre de l'Odéon.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "e00837f1-a5a9-5ea1-a396-0e094c21bd65",
+                date: "4 May",
+                description:
+                    "Samuel Beckett awarded the first Prix International des Editeurs, (also known later as the Prix Formentor, and the Prix International de littérature) shared with Jorge Luis Borges; Beckett does not attend the ceremony.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "ebd3cbd9-87b1-5a1a-b093-3d97285877c0",
+                date: "by 28 May",
+                description:
+                    "Barbara Bray and her daughters have moved to Paris.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "5a1c36d4-e15b-56a0-82e5-a8125e83165c",
+                date: "16 - 30 June",
+                description:
+                    "Beckett in Surrey with Sheila and Donald Page until 22 or 23 June, then in London.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "6b38c967-3264-5522-858e-8d074ce82098",
+                date: "26 June",
+                description:
+                    "BBC TV broadcasts <i>Waiting for Godot</i> directed by Donald McWhinnie.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "6c7bac86-b1a1-5c9d-9b28-b56215a6d6df",
+                date: "3 - 4 July",
+                description:
+                    "The Bielefeld production of Mihalovici's opera of <i>Krapp</i> performed as part of the Théâtre des Nations, Paris.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "e07788c1-89de-5cc3-9da6-4937fdc77626",
+                date: "5 July",
+                description:
+                    "Beckett attends John Osborne's <i>Luther</i> performed as part of the Théâtre des Nations, Paris.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "986b5c78-1f1b-5232-91bf-c468a82c8193",
+                date: "15 July",
+                description:
+                    "Beckett begins English translation of <i>Comment c'est</i>.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "bc6aa7c6-8308-5eb5-b6e5-e934e1f357b8",
+                date: "11-22 August",
+                description:
+                    "Increasingly frequent OAS attacks in many areas of France.",
+                type: "global",
+                additional: "none",
+            },
+            {
+                id: "82e6388b-c92d-5074-a0b2-0a13ff8c0ff2",
+                date: "13 August",
+                description:
+                    "The German Democratic Republic (GDR) begins construction of the Berlin Wall.",
+                type: "global",
+                additional: "none",
+            },
+            {
+                id: "302ed3b4-4df1-5879-bd8e-e03d5195b462",
+                date: "20-23 August",
+                description: "Beckett and Suzanne in Etretat, France.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "da6ad442-4594-5032-b99a-61d3b8c1a1de",
+                date: "1-11 September",
+                description: "Samuel Beckett in England.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "11fef5de-d224-5a5e-aedb-89fe5f5b4e5e",
+                date: "8 September",
+                description: "Failed attempt on the life of General de Gaulle.",
+                type: "global",
+                additional: "none",
+            },
+            {
+                id: "7115812b-32fd-5760-877c-ea18b34262dc",
+                date: "17 September",
+                description:
+                    "World premiere of <i>Happy Days</i> at the Cherry Lane Theatre, New York, directed by Alan Schneider.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "74c8d486-3e26-5170-a919-2fc597fc7fd8",
+                date: "24 October",
+                description:
+                    "Opening of Bram van Velde's retrospective, Knoedler Gallery, Paris.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "d1aa71e3-045a-55d5-8291-200e85157dae",
+                date: "by 10 December",
+                description:
+                    "Samuel Beckett's Poems in English published by John Calder.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "3010794b-0a77-5ab8-927e-a8fad373acaa",
+                date: "13 December",
+                description:
+                    "Samuel Beckett sends petition to John Calder and Harold Hobson for signatures to protest against the trial of Jérôme Lindon for his publication of The Deserter and for his anti-torture position on Algeria.",
+                type: "personal",
+                additional: "none",
+            },
+        ],
+    },
+    {
+        year: 1962,
+        events: [
+            {
+                id: "9d216dfe-2a3c-5726-bfa9-12cb1aa8fc31",
+                date: "12 January",
+                description:
+                    "Samuel Beckett in Ussy to complete draft translation of <i>How It Is</i>.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "65891cfb-4a92-59ae-85cf-aeee05c0bd33",
+                date: "8 February",
+                description:
+                    "Demonstration against the O.A.S. at the Charonne Métro Station provokes police response that ends in death of nine persons; this triggers a general strike in Paris on 13 February in Paris.",
+                type: "global",
+                additional: "none",
+            },
+            {
+                id: "2993a9ee-593a-5a5b-9796-a9c2f0d62fdf",
+                date: "11 February",
+                description: "Jean-Jacques Mayoux's home is bombed.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "57a4cddd-5a24-5b4e-83e1-0e2b143fbcda",
+                date: "20 February",
+                description:
+                    "Bram van Velde's first New York exhibition opens, Knoedler Gallery.",
+                type: "global",
+                additional: "none",
+            },
+            {
+                id: "f03631db-cdc4-5f58-87cf-94664fbe238b",
+                date: "18 March",
+                description:
+                    "With the signing of the Evian Accords, a ceasefire takes effect in Algeria on 19 March.",
+                type: "global",
+                additional: "none",
+            },
+            {
+                id: "db4ba065-cb46-55fd-98f2-af23bafc605a",
+                date: "5 May",
+                description:
+                    "Beckett attends Henri Hayden vernissage, Galerie Suillerot.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "afbdf331-0b52-53c6-a465-6d2fa0ef33cd",
+                date: "8 May",
+                description:
+                    "Beckett attends vernissage of Joan Mitchell double show, Galerie Jacques Dubourg and Galerie Lawrence, Paris.",
+                type: "personal",
+                additional: "image",
+            },
+            {
+                id: "235d9374-ed3c-57aa-9fcc-b406ecb7704b",
+                date: "before 15 May",
+                description:
+                    "Beckett has begun work on a play for three faces and lights (ultimately <i>Play</i>).",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "2c7e06f9-76e3-54cc-9833-13ba1ab56bc3",
+                date: "16 May",
+                description:
+                    "Samuel Beckett lunches with Igor and Vera Stravinsky in Paris.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "26020838-e4f9-53b9-aab0-9ad654b00b40",
+                date: "22 May",
+                description:
+                    "The BBC Third Programme broadcasts <i>Endgame</i>, produced by Michael Bakewell.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "ad9c0ae5-770d-5eea-9b12-f2f27caf8989",
+                date: "15 June",
+                description: "<i>Happy Days</i> published by Faber and Faber.",
+                type: "personal",
+                additional: "image",
+            },
+            {
+                id: "b8ac039d-93a7-54a6-9188-ba3e2f431674",
+                date: "17 June",
+                description:
+                    "Agreement signed between the Algerian FLN (National Liberation Front) and the OAS effectively ends the Algerian war.",
+                type: "global",
+                additional: "none",
+            },
+            {
+                id: "e0a9bcf3-c801-55aa-949e-01bbd65b76f2",
+                date: "3 July",
+                description:
+                    "After the approval of the Evian Accords by the electorate of Algeria, De Gaulle pronounces Algeria an independent country.",
+                type: "global",
+                additional: "none",
+            },
+            {
+                id: "35e7067c-686d-5728-9907-733b41341cc4",
+                date: "19 July",
+                description:
+                    "Beckett finishes draft of new play (<i>Play</i>).",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "50ce6da3-4379-5776-a37e-83a38c8e713c",
+                date: "5 August",
+                description:
+                    "Beckett attends Pinget double bill of <i>La Manivelle</i> and <i>Architruc</i> at the Comédie de Paris.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "96a6d4e9-238d-5745-826d-d5320eb2f5cd",
+                date: "7-25 August",
+                description: "Beckett holidays with Suzanne in Kitzbühel.",
+                type: "personal",
+                additional:
+                    "https://www.gettyimages.com/detail/photo/wilder-kaiser-mountain-range-royalty-free-image/15727808",
+            },
+            {
+                id: "ab7a5ec4-fd66-5fdc-9c6e-39bac1c05378",
+                date: "22 August",
+                description: "Second attempt on the life of General de Gaulle.",
+                type: "global",
+                additional: "none",
+            },
+            {
+                id: "de3fbd34-fc53-5a82-9258-c9568fffdd65",
+                date: "5 September",
+                description:
+                    "De Gaulle dissolves the French National Assembly, now allowing the President to be directly elected by the people.",
+                type: "global",
+                additional: "none",
+            },
+            {
+                id: "855c43f2-6918-55a0-acf7-ea218d40b566",
+                date: "21 September",
+                description:
+                    "Beckett sends complete manuscripts of <i>Cascando</i> to Herbert Myron for deposit in the Harvard University Theatre Collection.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "3ade59c1-b4d2-5128-bbf4-790185c7baf2",
+                date: "7 October",
+                description:
+                    "Samuel Beckett arrives in London to begin rehearsals of <i>Happy Days</i> on 8 October.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "9e060e67-e92c-5026-a1fd-415eb29e2dff",
+                date: "13 October",
+                description:
+                    "Attends Jack McGowran's runthrough of his one-man Beckett show, End of the Day. The BBC Third Programme broadcasts <i>Words and Music</i>.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "80dfff20-9364-5d7f-a2e8-a084e7f8babd",
+                date: "15 October",
+                description: "Start of the Cuban missile crisis.",
+                type: "global",
+                additional: "none",
+            },
+            {
+                id: "c54e905c-ef52-5ba4-bf77-bb6bb4dac0ba",
+                date: "1 November",
+                description:
+                    "London opening of <i>Happy Days</i> at the Royal Court Theatre. Samuel Beckett returns to Paris. Grants George Devine and the Royal Court Theatre first option on production of his future work in London.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "3a20b50b-c86b-5e96-9c46-6e79fb51c728",
+                date: "3 November",
+                description:
+                    "Samuel Beckett consults an eye specialist in Berne.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "54365085-8e51-50ec-a29c-c6fdb0bc6c5f",
+                date: "13 November",
+                description:
+                    "The BBC Third Programme broadcasts <i>Words and Music</i>.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "aa727388-ee4f-52ac-8eed-49873937eb76",
+                date: "19 November",
+                description:
+                    "Henri Hayden taken ill and hospitalized in London.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "4f95f3b3-a988-55ca-891e-de9a4db5cc47",
+                date: "before 27 December",
+                description:
+                    "Samuel Beckett attends Ionesco's <i>Le Roi se meurt</i> with George Devine, Jocelyn Herbert, and her daughter Jenny.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "f0b8406c-9602-57d8-b6b8-cba5148b29a9",
+                date: "27 December",
+                description:
+                    "Samuel Beckett attends with Robert Pinget, Roland Dubillard's <i>La Maison d'os</i>.",
+                type: "personal",
+                additional: "none",
+            },
+        ],
+    },
+    {
+        year: 1963,
+        events: [
+            {
+                id: "f7fea527-88e0-5932-8013-e9bbed6497f3",
+                date: "25 January",
+                description:
+                    "<i>Tous ceux qui tombent</i> broadcast on French Television with an introduction by Georges Belmont.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "bedce74e-b378-53e0-86e1-db1d1338ae9e",
+                date: "25 February",
+                description:
+                    "Beckett accepts Barney Rosset's commission to write a film.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "ac523698-e7a1-511a-b263-8888a6e4ddf6",
+                date: "20 March",
+                description:
+                    "<i>Poems in English</i> published by Grove Press.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "3b0ed662-b539-584c-b3b6-8ba03b9ddd3b",
+                date: "22 March",
+                description:
+                    "Attends Ramón Valle-Inclán's play <i>Divines paroles</i> at the Théâtre de l'Odéon, directed by Roger Blin.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "4abe5d29-e8c7-50ac-88c2-7b1a56003670",
+                date: "5 April",
+                description:
+                    "Beckett begins a manuscript notebook of <i>Film</i>.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "96ad96b0-d98a-54eb-90a2-00d348bd6f58",
+                date: "13 April",
+                description: "Completes first draft of <i>Film</i>.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "f611d84e-17af-5587-8336-7ea49e469aa5",
+                date: "week of 15 April",
+                description:
+                    "Beckett works with Jean-Marie Serreau on Comédie.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "1b31a180-7aed-5291-94a9-1c6ccdb4097b",
+                date: "10 May",
+                description:
+                    "Attends King Lear directed by Peter Brook at the Théâtre Sarah-Bernhardt.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "daa37462-648c-57b8-a0af-8eae7ad2073c",
+                date: "13 May",
+                description:
+                    "Samuel Beckett agrees to an embargo against performance of his plays before segregated audiences in South Africa.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "6d3e3d07-fec2-5009-9b62-14f80f8535dd",
+                date: "16 May - 6 June",
+                description:
+                    "Beckett attends rehearsals and recordings of <i>Cascando</i>, RTF studios.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "4f1c8d86-f5f8-57f2-8612-e2cf8e278ac0",
+                date: "30 May",
+                description:
+                    "With Alan Schneider, Beckett attends two working sessions of Spiel in Ulm, Germany.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "5fed6ffd-7b9f-5843-a43c-216677c87f16",
+                date: "3 June",
+                description: "Death of Pope John XXIII.",
+                type: "global",
+                additional: "image",
+            },
+            {
+                id: "1e5d44a5-08f2-5cba-886b-b30dd74d6873",
+                date: "14 June",
+                description:
+                    "Premiere of Spiel at the Ulmer-Theater, Ulm-Donau, directed by Deryk Mendel.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "40c7ab8b-cd03-58ea-928a-b6e31dc3caca",
+                date: "before 17 June",
+                description:
+                    "Beckett rehearses Oh Les beaux jours with Madeleine Renaud and Roger Blin.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "d92002a6-8b48-5035-bac6-ff78106f2897",
+                date: "17 June - 16 July",
+                description:
+                    "Samuel Beckett holidays with Suzanne in Zell-am-See, Austria.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "f1f0407f-0916-5988-8bbb-71e7b773c4da",
+                date: "21 June",
+                description: "Election of Cardinal Montini as Pope Paul VI.",
+                type: "global",
+                additional: "none",
+            },
+            {
+                id: "0da0c5a3-ab4a-5993-a397-217a029f1b10",
+                date: "29 July",
+                description: "A. J. Leventhal moves from Dublin to Paris.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "20a88f26-e491-58bb-a34d-084bcea9531e",
+                date: "before 20 August",
+                description:
+                    "Samuel Beckett writes a brief tribute to Richard Aldington.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "4ab0e707-534b-5395-b6ac-87521ce7b05b",
+                date: "24 August",
+                description:
+                    "Samuel Beckett begins a play for a lit face (“Kilcool”; TCD, MS 4664).",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "7521b05e-6bda-5949-91ef-bbd5799be3f9",
+                date: "27 September",
+                description:
+                    "Premiere of Oh les beaux jours at the Teatro del Ridotto, as part of the Venice Festival.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "9d21a275-fd18-5938-aa7c-0002653b20c0",
+                date: "30 September",
+                description:
+                    "<i>Happy Days</i> opens at the Eblana Theatre, Dublin, directed by John Beary, with Marie Kean.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "1c8c8596-9743-5b27-84f1-b1c7a4fc61ba",
+                date: "13 October",
+                description: "ORTF-France Culture broadcasts <i>Cascando</i>.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "a84872bd-f998-5a6a-8e53-494c752b047d",
+                date: "15 November",
+                description:
+                    "Beckett asks Faber and Faber to publish the unexpurgated version of <i>Waiting for Godot</i>.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "178f6748-b955-5496-bb60-4d997b0624ab",
+                date: "22 November",
+                description:
+                    "Assassination of John F. Kennedy. Lyndon B. Johnson becomes President of the United States.",
+                type: "global",
+                additional: "image",
+            },
+        ],
+    },
+    {
+        year: 1964,
+        events: [
+            {
+                id: "0002742d-8f47-5f1a-be7d-c4dca682c8df",
+                date: "4 January",
+                description:
+                    "Play opens at the Cherry Lane Theatre, New York, directed by Alan Schneider, on a double bill with Harold Pinter's The Lover.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "07c54ff1-c88b-5b82-a08a-af77a3eb065a",
+                date: "16 January - 5 February",
+                description:
+                    "Beckett in London for rehearsals of <i>Endgame</i> with Patrick Magee and Jack MacGowran.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "668a3adc-e237-57a8-8702-45fe763cdc3a",
+                date: "25 January",
+                description:
+                    "Beckett attends playback of <i>Cascando</i> as recorded in Stuttgart.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "1083757f-4984-5ff5-b3f1-eb63c87a98eb",
+                date: "28 January",
+                description:
+                    "Attends the opening night of Max Frisch's play Andorra at the Old Vic.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "eeaf3e14-b908-5097-89ce-63802665dfc8",
+                date: "29 January",
+                description:
+                    "Attends “Theatre of Cruelty” productions, organized by Charles Marowitz and Peter Brook, at LAMDA.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "73a9e38c-456f-565c-a92e-72d13d74ee3b",
+                date: "4 February",
+                description:
+                    "Attends dress rehearsal of Who's Afraid of Virginia Woolf, directed by Alan Schneider, Piccadilly Theatre, London.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "1db21f7b-87cd-5305-911f-ed0201ddf00e",
+                date: "17 February",
+                description:
+                    "<i>Endgame</i> with Jack MacGowran and Patrick Magee opens at the Studio des Champs-Elysées.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "32fc11bc-491f-5bf4-abd4-c68ec1e55fbc",
+                date: "24 February",
+                description:
+                    "Goddard Lieberson's invites Beckett to contribute to a Homage for John F. Kennedy. Beckett declines.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "87d09e8c-8da7-5389-9fd0-41381602c1ff",
+                date: "14 March - 8 April",
+                description: "Samuel Beckett in London for rehearsals of Play.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "c9bd677f-d452-5fcc-a093-507b7b2dde8d",
+                date: "21-22 March",
+                description:
+                    "Spends weekend with George Devine and Jocelyn Herbert at their farm, “Andrews,” in Hampshire.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "95b21a32-af25-50f5-a76a-24eff3b1aa5f",
+                date: "7 April",
+                description:
+                    "Play opens at the National Theatre, Old Vic, on a double bill with Sophocles' Philoctetes.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "53108c2a-d00b-511b-8f65-e749e1d85c5a",
+                date: "10 April",
+                description:
+                    "Samuel Beckett writes tribute to Brendan Behan for Theater heute.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "af04d1e8-ba33-52c3-85cf-f30e45f519fa",
+                date: "14 April",
+                description:
+                    "Samuel Beckett resumes rehearsals in Paris for Comédie, directed by Jean-Marie Serreau.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "2c58685d-c00f-5e2c-aaca-4c2f5d8736cd",
+                date: "21 April",
+                description: "Gisèle Freund photographs Samuel Beckett.",
+                type: "personal",
+                additional:
+                    "https://upload.wikimedia.org/wikipedia/en/2/22/Self_Portrait_of_Gisele_Freund.jpg",
+            },
+            {
+                id: "fa5476fd-d891-5cd9-bdaa-f285f05b8d28",
+                date: "30 April",
+                description: "<i>How It Is</i> published by John Calder.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "1ec9baba-ac06-5cec-9441-3f9bc57e7750",
+                date: "20 May",
+                description:
+                    "Henri Cartier-Bresson photographs Beckett in Paris.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "ce7b8ff8-47b2-55fc-bfb9-3c27f107e48a",
+                date: "June",
+                description: "Comédie published in Les Lettres Nouvelles.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "c6f3e9cd-ed5f-5ce6-a345-6bd015333559",
+                date: "11 June",
+                description:
+                    "Comédie opens at the Pavillon de Marsan, as part of the Estival 1964, directed by Jean-Marie Serreau, assisted by Samuel Beckett.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "39a9a127-39cd-531e-80fa-f2179c497f2a",
+                date: "12 June",
+                description:
+                    "Nelson Mandela sentenced to life imprisonment in South Africa.",
+                type: "global",
+                additional:
+                    "https://upload.wikimedia.org/wikipedia/commons/1/11/Young_Mandela.jpg",
+            },
+            {
+                id: "ecef8900-9078-5e09-84df-13513c92e0a3",
+                date: "29 June-9 July",
+                description:
+                    "Samuel Beckett in London to assist Donald McWhinnie with rehearsals of <i>Endgame</i>, with Jack MacGowran and Patrick Magee.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "6e222585-7ecb-54c0-b8e2-636753f694e2",
+                date: "9 July",
+                description: "<i>Endgame</i> opens at the Aldwych Theatre.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "18004d3d-ec37-51d8-b58d-4f679068050d",
+                date: "10 July - 6 August",
+                description:
+                    "Beckett flies from London to New York for work on <i>Film</i>.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "bbcd37dc-d582-5514-8d1c-ee93e15cb197",
+                date: "11-12 July",
+                description:
+                    "Stays at Barney Rosset's home in East Hampton, works with Alan Schneider and cameraman Boris Kaufman on plans for <i>Film</i>.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "d2f96bfd-790e-5d9a-8fe8-815fc65c3d3d",
+                date: "20 July",
+                description:
+                    "Murphy, published by Calder and Boyars, is banned in Ireland.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "531f4aca-be5c-5c6f-8ed7-d762232e0d05",
+                date: "23 July",
+                description:
+                    "Beckett attends Dutchman by LeRoi Jones (later Amiri Baraka) and The American Dream by Edward Albee at Cherry Lane Theatre.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "95b18358-6718-5a49-8a97-838f4120981f",
+                date: "30 July",
+                description: "Final day of shooting of <i>Film</i>.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "9d78be85-7028-56ec-8c90-bd6525034c8b",
+                date: "1 and 2 August",
+                description:
+                    "Beckett works with Sidney Meyers, the editor of <i>Film</i>.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "bee57603-afa3-56fc-b2d9-6a404d0e3681",
+                date: "15 August",
+                description: "Death of Leslie Daiken, in London.",
+                type: "global",
+                additional: "none",
+            },
+            {
+                id: "2b769aa3-c52a-5601-a7fa-094d4cecf53a",
+                date: "by 21 August",
+                description:
+                    "Samuel Beckett has begun to write first of four pieces which will later be called “Faux départs.”",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "a7eefbfd-5a20-5d58-8a9f-d061040ee005",
+                date: "18 September",
+                description: "Death of Sean O'Casey.",
+                type: "global",
+                additional:
+                    "https://upload.wikimedia.org/wikipedia/commons/9/9a/Sean_ocasey_1924.jpg",
+            },
+            {
+                id: "ce27a2cd-2de5-594a-a0bf-eb2a770a8ef6",
+                date: "6 October",
+                description:
+                    "<i>Cascando</i> broadcast on the BBC Third Program. ",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "2bea7069-56b6-5c5c-a971-8048bad550a8",
+                date: "20 October",
+                description:
+                    "Samuel Beckett halts republication of <i>More Pricks Than Kicks</i> by Grove Press and John Calder.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "2d6aee25-4456-52b3-bbda-576a4b937fdb",
+                date: "12 - 31 December",
+                description:
+                    " Beckett in London for rehearsals of <i>Waiting for Godot</i>, directed by Anthony Page at the Royal Court Theatre.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "c0774e8c-9139-53ee-b782-a0bc0f6a730b",
+                date: "10 December",
+                description:
+                    "Jean-Paul Sartre refuses the Nobel Prize in Literature.",
+                type: "global",
+                additional:
+                    "https://upload.wikimedia.org/wikipedia/commons/e/e9/Jean_Paul_Sartre_1965.jpg",
+            },
+            {
+                id: "d7fab0bc-13b7-5872-a068-a1b3974ec851",
+                date: "30 December",
+                description:
+                    "<i>Waiting for Godot</i> opens at the Royal Court Theatre with Patrick Magee and Nicol Williamson.",
+                type: "personal",
+                additional: "none",
+            },
+        ],
+    },
+    {
+        year: 1965,
+        events: [
+            {
+                id: "17a20b7c-bf68-58e3-a5fd-665cf36a697e",
+                date: "5 February",
+                description:
+                    "Beckett called to Berlin to help with Schiller-Theater production of <i>Warten auf Godot</i>, directed by Deryk Mendel.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "be27eab6-0719-57f2-a965-ac4281cf226e",
+                date: "18 February",
+                description:
+                    "Beckett flies from Berlin to London to assist with rehearsals of Jack MacGowran's <i>Beginning to End</i>.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "bf80861f-9426-5f2d-a009-45035e752ca6",
+                date: "19 February",
+                description:
+                    "Attends <i>Marat/Sade</i>, by Peter Weiss, directed by Peter Brook, with Patrick Magee as the Marquis de Sade.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "2698b6f6-f2e5-5911-9517-267863b9f170",
+                date: "21 February",
+                description:
+                    "Beckett returns to Berlin from London to resume rehearsals of <i>Warten auf Godot</i>.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "cc806b20-0b87-56a9-a72c-be2d29a0ef5c",
+                date: "27 February",
+                description: "Beckett flies from Berlin to Paris.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "1f8c803a-936b-58ef-a392-1ea978abec63",
+                date: "28 February",
+                description:
+                    "Samuel Beckett learns that Italian actress Clara Colosimo has gone on hunger strike because she cannot get permission to perform Giorni felici (<i>Happy Days</i>).",
+                type: "personal",
+                additional: "image?",
+            },
+            {
+                id: "2283997e-d5a8-5a1e-9190-baee52481f32",
+                date: "2 March",
+                description:
+                    "Launch of Operation Rolling Thunder, a sustained American bombing campaign of North Vietnam that lasts until 2 November 1968.",
+                type: "global",
+                additional: "none",
+            },
+            {
+                id: "3eb45134-e4f4-5035-9873-6a9132eb46bd",
+                date: "11 March",
+                description:
+                    "Beckett views latest cut of <i>Film</i> and sends his notes on to Schneider the following day.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "d6ed8d53-057a-5ea0-9a74-ddcdb048c470",
+                date: "17 March",
+                description: "Death of Nancy Cunard in Paris.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "b793eba3-29e5-5441-83d2-39b23e724e4e",
+                date: "21 March",
+                description:
+                    "Beckett completes a draft of <i>Va-et-vient</i>, French translation of <i>Come and Go</i>.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "a0ac3b47-67e5-5d07-9b18-7a392911628f",
+                date: "7 April",
+                description:
+                    "Beckett sends third and fourth (final) draft of <i>How It Is</i> to Henry Wenning as a gift to the Boston University Beckett collection.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "35dec491-8203-5c30-83c9-f2211cad3fd3",
+                date: "13 April",
+                description:
+                    "Beckett writes <i>Eh Joe</i> for television, a play for Jack MacGowran.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "a3c94654-769a-5c88-8ab4-c0bf00de22f8",
+                date: "6 May",
+                description:
+                    "Unexpurgated edition of <i>Waiting for Godot</i> published by Faber and Faber.",
+                type: "personal",
+                additional:
+                    "https://i2.wp.com/i1083.photobucket.com/albums/j391/bookkarino/13453814_zpsywj532ak.jpg",
+            },
+            {
+                id: "bb46d6c3-8ee9-549b-a270-4a93554408b4",
+                date: "15 May",
+                description:
+                    "Beckett completes <i>Eh Joe</i> and sends to Jack MacGowran, Donald McWhinnie, and Curtis Brown.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "e258d354-4414-56de-8b94-45c0448c32e6",
+                date: "20 June",
+                description:
+                    "Beckett and Suzanne fly to Turin, travelling on to Courmayeur on 22 June for a holiday.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "c606405f-ca34-57aa-8a30-77148c84e012",
+                date: "3 July",
+                description:
+                    "Beckett completes the French translation <i>Dis Joe</i>.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "7a7b2e20-3639-5512-967b-13f6a1eff365",
+                date: "4-8 July",
+                description:
+                    "Beckett translates <i>Imagination morte imaginez</i> into English.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "2e75b6b4-23cd-54db-9dfe-73bf74f1d4f1",
+                date: "14 July",
+                description:
+                    "Beckett returns to Paris from Courmayeur via Turin.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "91361c2b-1108-57d7-8359-2d5730cb43d8",
+                date: "16 July",
+                description:
+                    "Opening of the Mont Blanc Tunnel between France and Italy.",
+                type: "global",
+                additional:
+                    "https://upload.wikimedia.org/wikipedia/commons/a/a0/Mont_Blanc_Tunnel_French_Side.jpg",
+            },
+            {
+                id: "b39c584c-ec78-5321-8a9e-584f3f0c5240",
+                date: "19 July",
+                description: "Samuel Beckett has surgery on jaw.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "a1d18c75-afc3-58d5-85ef-f8461384a2bf",
+                date: "8 August",
+                description:
+                    "Beckett begins French translation of <i>Words and Music</i>; draft translation completed on 14 August.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "fe1a090c-777e-5cfa-86d6-5642cd9f80a6",
+                date: "4 September",
+                description:
+                    "Premiere of <i>Film</i> at the Venice <i>Film</i> Festival. Samuel Beckett begins draft of <i>Assez</i>.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "7f8af77b-4f2f-575d-91c9-b5d4e245823d",
+                date: "November",
+                description:
+                    "Annales (Toulouse) publishes an extract from <i>Mercier et Camier</i> (as yet unpublished novel, 1946).",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "51ee9ed0-beba-56dd-a4dc-41ea5ab7e826",
+                date: "mid-November to 5 December",
+                description:
+                    "Beckett in Ussy, working on <i>Le Dépeupleur</i>. Completes first draft on 28 November.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "e778ff38-b834-529b-ae2a-67dd527b84cf",
+                date: "7 December",
+                description:
+                    "Samuel Beckett begins work with director Marin Karmitz on a film of <i>Comédie in Paris</i>.",
+                type: "personal",
+                additional: "none",
+            },
+            {
+                id: "cacfce2e-3575-5a41-afa3-c38d5b8e2148",
+                date: "12 December",
+                description:
+                    "Charles de Gaulle is reelected as French President, defeating François Mitterrand.",
+                type: "global",
+                additional:
+                    "https://upload.wikimedia.org/wikipedia/commons/e/e2/Charles_de_Gaulle_Mr_VIE_Isles_sur_Suippe.jpg",
+            },
+            {
+                id: "ddd7dcaf-2fb1-5b45-9ceb-2f1cf4681051",
+                date: "21 January",
+                description:
+                    "Beckett has completed manuscript of <i>Come and Go</i> and sends it to Barbara Bray.",
+                type: "personal",
+                additional: "none",
             },
         ],
     },

--- a/src/data/timelineData.js
+++ b/src/data/timelineData.js
@@ -2408,7 +2408,7 @@ export const timelineData = [
         ],
     },
     {
-        year: 1958,
+        year: 1959,
         events: [
             {
                 id: "0720f1b4-27c3-54e5-9873-85d1184b08dd",

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -11,6 +11,7 @@ import {
     LetterPage,
     letterLoader,
     LettersSearchPage,
+    TimeLinePage,
 } from "./pages";
 import { Root } from "./Root";
 import "./assets/index.css";
@@ -39,6 +40,10 @@ const router = createBrowserRouter([
                 path: "letters/:letterId",
                 element: <LetterPage />,
                 loader: letterLoader,
+            },
+            {
+                path: "timeline",
+                element: <TimeLinePage />,
             },
         ],
     },

--- a/src/pages/TimelinePage/TimelinePage.css
+++ b/src/pages/TimelinePage/TimelinePage.css
@@ -1,7 +1,15 @@
+.timeline-page {
+    height: calc(100vh - 48px);
+}
+
+.timeline-nav button {
+    margin: 0.25rem 0;
+}
+
 .timeline-year-header {
-    background-color: #fff;
+    background-color: #fafbfd;
     position: sticky;
-    top: 0;
+    top: -1px;
     z-index: 1;
 }
 

--- a/src/pages/TimelinePage/TimelinePage.css
+++ b/src/pages/TimelinePage/TimelinePage.css
@@ -1,0 +1,28 @@
+.timeline-year-header {
+    background-color: #fff;
+    position: sticky;
+    top: 0;
+    z-index: 1;
+}
+
+.vertical-timeline {
+    position: relative;
+}
+
+.timeline-event h2 {
+    padding: 0.75rem 1rem;
+}
+
+.timeline-event-type-personal .vertical-timeline-element-content h2 {
+    background-color: #007dba;
+    color: #fff;
+    text-align: end;
+}
+
+.timeline-event-type-global h2 {
+    background-color: #e6b965;
+}
+
+.timeline-event p {
+    padding: 0 1rem 1rem;
+}

--- a/src/pages/TimelinePage/TimelinePage.jsx
+++ b/src/pages/TimelinePage/TimelinePage.jsx
@@ -76,7 +76,12 @@ export function TimeLinePage() {
                                             className={`timeline-event timeline-event-type-${event.type}`}
                                         >
                                             <h2>{event.date}</h2>
-                                            <p>{event.description}</p>
+                                            <p
+                                                // eslint-disable-next-line react/no-danger
+                                                dangerouslySetInnerHTML={{
+                                                    __html: event.description,
+                                                }}
+                                            />
                                         </VerticalTimelineElement>
                                     );
                                 })}

--- a/src/pages/TimelinePage/TimelinePage.jsx
+++ b/src/pages/TimelinePage/TimelinePage.jsx
@@ -31,12 +31,16 @@ export function TimeLinePage() {
         // observer. It get's all wonky/messy when someone is scrolling. This
         // will do for now.
         document.getElementById(id).scrollIntoView({ behavior: "instant" });
-        setCurrentYear(id);
+        setTimeout(() => setCurrentYear(id), 100);
     };
 
     return (
-        <main ref={containerRef}>
-            <EuiPage paddingSize="none">
+        <main>
+            <EuiPage
+                ref={containerRef}
+                paddingSize="none"
+                className="timeline-page"
+            >
                 <EuiPageSideBar sticky paddingSize="l">
                     <nav className="timeline-nav">
                         {years.map((year) => (
@@ -51,7 +55,7 @@ export function TimeLinePage() {
                         ))}
                     </nav>
                 </EuiPageSideBar>
-                <EuiPageBody className="timeline-page">
+                <EuiPageBody>
                     <section style={{ overflow: "auto" }}>
                         {timelineData.map((year) => (
                             <TimelineYear

--- a/src/pages/TimelinePage/TimelinePage.jsx
+++ b/src/pages/TimelinePage/TimelinePage.jsx
@@ -1,19 +1,9 @@
-import {
-    EuiPage,
-    EuiPageBody,
-    EuiPageSideBar,
-    EuiSideNav,
-    EuiText,
-    EuiTextAlign,
-} from "@elastic/eui";
-import {
-    VerticalTimeline,
-    VerticalTimelineElement,
-} from "react-vertical-timeline-component";
-import React from "react";
+import { EuiButton, EuiPage, EuiPageBody, EuiPageSideBar } from "@elastic/eui";
+import React, { useRef, useState } from "react";
 import { timelineData } from "../../data/timelineData";
 import "react-vertical-timeline-component/style.min.css";
 import "./TimelinePage.css";
+import TimelineYear from "../../components/TimelineYear";
 
 /**
  * Page for timeline.
@@ -22,72 +12,57 @@ import "./TimelinePage.css";
  */
 export function TimeLinePage() {
     const years = timelineData.map(({ year }) => ({
-        name: year,
-        id: `nav-${year}`,
+        label: year,
+        id: `year-${year}`,
         href: `#year-${year}`,
     }));
 
+    const [currentYear, setCurrentYear] = useState(years[0].id);
+    const containerRef = useRef();
+
+    /**
+     * Handle navigating to year when button is clicked.
+     *
+     @param {string} id Element ID of year that was clicked.
+     */
+    const handleClick = (id) => {
+        // Ideally, this would be an effect on the TimeLineYear component when
+        // currentYear is updated. But the currentYear is updated by the intersection
+        // observer. It get's all wonky/messy when someone is scrolling. This
+        // will do for now.
+        document.getElementById(id).scrollIntoView({ behavior: "instant" });
+        setCurrentYear(id);
+    };
+
     return (
-        <main>
-            <EuiPage paddingSize="l">
-                <EuiPageSideBar sticky>
-                    <EuiSideNav items={years} />
-                </EuiPageSideBar>
-                <EuiPageBody>
-                    {timelineData.map((year) => (
-                        <section key={year.year} id={`year-${year.year}`}>
-                            <EuiText className="timeline-year-header">
-                                <EuiTextAlign textAlign="center">
-                                    <h1>{year.year}</h1>
-                                </EuiTextAlign>
-                            </EuiText>
-                            <VerticalTimeline
-                                lineColor="#b1b3b3"
-                                animate={false}
+        <main ref={containerRef}>
+            <EuiPage paddingSize="none">
+                <EuiPageSideBar sticky paddingSize="l">
+                    <nav className="timeline-nav">
+                        {years.map((year) => (
+                            <EuiButton
+                                key={year.label}
+                                onClick={() => handleClick(year.id)}
+                                id={`nav-${year.label}`}
+                                fill={year.id === currentYear}
                             >
-                                {year.events.map((event) => {
-                                    const color =
-                                        event.type === "personal"
-                                            ? "#007dba"
-                                            : "#e6b965";
-                                    return (
-                                        <VerticalTimelineElement
-                                            key={event.id}
-                                            position={
-                                                event.type === "personal"
-                                                    ? "left"
-                                                    : "right"
-                                            }
-                                            iconStyle={{
-                                                background: color,
-                                                marginTop: "-10px",
-                                            }}
-                                            contentArrowStyle={{
-                                                borderRight: `7px solid  ${color}`,
-                                                top: "10px",
-                                            }}
-                                            contentStyle={{
-                                                borderColor: color,
-                                                borderStyle: "solid",
-                                                borderWidth: "thin",
-                                                boxShadow: "none",
-                                                padding: "0",
-                                            }}
-                                            className={`timeline-event timeline-event-type-${event.type}`}
-                                        >
-                                            <h2>{event.date}</h2>
-                                            <p
-                                                // eslint-disable-next-line react/no-danger
-                                                dangerouslySetInnerHTML={{
-                                                    __html: event.description,
-                                                }}
-                                            />
-                                        </VerticalTimelineElement>
-                                    );
-                                })}
-                            </VerticalTimeline>
-                        </section>
-                    ))}
+                                {year.label}
+                            </EuiButton>
+                        ))}
+                    </nav>
+                </EuiPageSideBar>
+                <EuiPageBody className="timeline-page">
+                    <section style={{ overflow: "auto" }}>
+                        {timelineData.map((year) => (
+                            <TimelineYear
+                                key={`timeline-${year.year}`}
+                                data={year}
+                                currentYear={currentYear}
+                                setCurrentYear={setCurrentYear}
+                                root={containerRef.current}
+                            />
+                        ))}
+                    </section>
                 </EuiPageBody>
             </EuiPage>
         </main>

--- a/src/pages/TimelinePage/TimelinePage.jsx
+++ b/src/pages/TimelinePage/TimelinePage.jsx
@@ -1,0 +1,90 @@
+import {
+    EuiPage,
+    EuiPageBody,
+    EuiPageSideBar,
+    EuiSideNav,
+    EuiText,
+    EuiTextAlign,
+} from "@elastic/eui";
+import {
+    VerticalTimeline,
+    VerticalTimelineElement,
+} from "react-vertical-timeline-component";
+import React from "react";
+import { timelineData } from "../../data/timelineData";
+import "react-vertical-timeline-component/style.min.css";
+import "./TimelinePage.css";
+
+/**
+ * Page for timeline.
+ *
+ * @returns {React.Component} entity page component.
+ */
+export function TimeLinePage() {
+    const years = timelineData.map(({ year }) => ({
+        name: year,
+        id: `nav-${year}`,
+        href: `#year-${year}`,
+    }));
+
+    return (
+        <main>
+            <EuiPage paddingSize="l">
+                <EuiPageSideBar sticky>
+                    <EuiSideNav items={years} />
+                </EuiPageSideBar>
+                <EuiPageBody>
+                    {timelineData.map((year) => (
+                        <section key={year.year} id={`year-${year.year}`}>
+                            <EuiText className="timeline-year-header">
+                                <EuiTextAlign textAlign="center">
+                                    <h1>{year.year}</h1>
+                                </EuiTextAlign>
+                            </EuiText>
+                            <VerticalTimeline
+                                lineColor="#b1b3b3"
+                                animate={false}
+                            >
+                                {year.events.map((event) => {
+                                    const color =
+                                        event.type === "personal"
+                                            ? "#007dba"
+                                            : "#e6b965";
+                                    return (
+                                        <VerticalTimelineElement
+                                            key={event.id}
+                                            position={
+                                                event.type === "personal"
+                                                    ? "left"
+                                                    : "right"
+                                            }
+                                            iconStyle={{
+                                                background: color,
+                                                marginTop: "-10px",
+                                            }}
+                                            contentArrowStyle={{
+                                                borderRight: `7px solid  ${color}`,
+                                                top: "10px",
+                                            }}
+                                            contentStyle={{
+                                                borderColor: color,
+                                                borderStyle: "solid",
+                                                borderWidth: "thin",
+                                                boxShadow: "none",
+                                                padding: "0",
+                                            }}
+                                            className={`timeline-event timeline-event-type-${event.type}`}
+                                        >
+                                            <h2>{event.date}</h2>
+                                            <p>{event.description}</p>
+                                        </VerticalTimelineElement>
+                                    );
+                                })}
+                            </VerticalTimeline>
+                        </section>
+                    ))}
+                </EuiPageBody>
+            </EuiPage>
+        </main>
+    );
+}

--- a/src/pages/TimelinePage/index.js
+++ b/src/pages/TimelinePage/index.js
@@ -1,0 +1,1 @@
+export * from "./TimelinePage";

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -4,3 +4,4 @@ export * from "./ErrorPage";
 export * from "./HomePage";
 export * from "./LetterPage";
 export * from "./LettersSearchPage";
+export * from "./TimelinePage";


### PR DESCRIPTION
This adds a page timeline/chronology. The aim is to replicate [this](https://beckettletters.ecdsdev.org/timeline). It would be great to get feedback of organization (location of the data). I also need to look at what tags the timeline component is using and if it fits in with the overall semantics - I doubt it does.

Also, there many more years to be added.