### PR TITLE
Prevent unwanted firing of sort, operator effects

### DIFF
--- a/src/pages/EntitiesSearchPage/EntitiesSearchPage.jsx
+++ b/src/pages/EntitiesSearchPage/EntitiesSearchPage.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import {
     SearchkitClient,
@@ -91,6 +91,7 @@ function EntitiesSearch() {
         config: entitiesSearchConfig,
         fields,
     });
+    const sortStateMounted = useRef(false);
     const [sortState, setSortState] = useState(() => {
         if (searchParams?.has("sort")) {
             const [field, dir] = searchParams.get("sort").split("_");
@@ -129,7 +130,10 @@ function EntitiesSearch() {
     }, [searchParams]);
     useEffect(() => {
         // handle sorting separately in order to only update in case of changes
-        if (sortState) {
+        // use mounted ref to ensure we don't fire this effect on initial value
+        if (!sortStateMounted.current) {
+            sortStateMounted.current = true;
+        } else if (sortState) {
             const sortBy = getSortByFromState(sortState);
             if (
                 !searchParams.has("sort") ||
@@ -151,7 +155,8 @@ function EntitiesSearch() {
         if (
             operator &&
             searchParams &&
-            (!searchParams.has("op") || searchParams.get("op") !== operator)
+            ((!searchParams.has("op") && operator !== "or") ||
+                (searchParams.has("op") && searchParams.get("op") !== operator))
         ) {
             setSearchParams(
                 stateToRoute({

--- a/src/pages/LettersSearchPage/LettersSearchPage.jsx
+++ b/src/pages/LettersSearchPage/LettersSearchPage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useSearchParams } from "react-router-dom";
 import {
     SearchkitClient,
@@ -84,6 +84,7 @@ function LettersSearch() {
     );
     const [dateRangeState, setDateRangeState] = useDateFilter();
     const [scope, setScope] = useScope();
+    const sortStateMounted = useRef(false);
     const [sortState, setSortState] = useState(() => {
         if (searchParams?.has("sort")) {
             const [field, dir] = searchParams.get("sort").split("_");
@@ -131,7 +132,10 @@ function LettersSearch() {
     }, [searchParams]);
     useEffect(() => {
         // handle sorting separately in order to only update in case of changes
-        if (sortState) {
+        // use mounted ref to ensure we don't fire this effect on initial value
+        if (!sortStateMounted.current) {
+            sortStateMounted.current = true;
+        } else if (sortState) {
             const sortBy = getSortByFromState(sortState);
             if (
                 !searchParams.has("sort") ||
@@ -153,7 +157,8 @@ function LettersSearch() {
         if (
             operator &&
             searchParams &&
-            (!searchParams.has("op") || searchParams.get("op") !== operator)
+            ((!searchParams.has("op") && operator !== "or") ||
+                (searchParams.has("op") && searchParams.get("op") !== operator))
         ) {
             setSearchParams(
                 stateToRoute({


### PR DESCRIPTION
## In this PR

Bug fix for the back button failing when certain parameters (sort, operator) are not present in the URL, due to unwanted effects firing. Fixed by preventing each of the effects from firing on the states' default instantiations, which resulted in requests using incomplete filters data from Searchkit.